### PR TITLE
Adapt Frontend to Miner / MinerStateSnapshot Split

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.0",
+  "version": "0.1.0-rev1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.0-rev1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/dashboard/MinerTile.vue
+++ b/src/components/dashboard/MinerTile.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Miner } from "../../core/models/miner";
+import type { Miner, MinerStatus, MinerStateSnapshot } from "../../core/models/miner";
 import { computed } from "vue";
 import {
   PhPower,
@@ -13,11 +13,13 @@ import { formatHashRate, formatPower, normalizeHashRate } from "../../core/utils
 
 const props = defineProps<{
   miner: Miner;
+  state?: MinerStateSnapshot;
 }>();
 
-const isOn = computed(() => props.miner.status === "on");
+const currentStatus = computed<MinerStatus>(() => props.state?.status ?? 'unknown');
+const isOn = computed(() => currentStatus.value === "on");
 const isTransitioning = computed(
-  () => props.miner.status === "starting" || props.miner.status === "stopping"
+  () => currentStatus.value === ('starting' satisfies MinerStatus) || currentStatus.value === ('stopping' satisfies MinerStatus)
 );
 
 const statusConfig = computed(() => {
@@ -29,13 +31,13 @@ const statusConfig = computed(() => {
     error: { color: "text-red-400", bg: "bg-red-500/10", border: "border-red-500/30", label: "Error", icon: PhWarningCircle },
     unknown: { color: "text-base-content/30", bg: "bg-base-100/20", border: "border-base-300/20", label: "Unknown", icon: PhQuestion },
   };
-  return configs[props.miner.status] || configs.unknown;
+  return configs[currentStatus.value] || configs.unknown;
 });
 
 // Hash rate % of max (normalized to common unit)
 const hashRatePct = computed(() => {
-  if (!props.miner.hash_rate?.value || !props.miner.hash_rate_max?.value) return 0;
-  const current = normalizeHashRate(props.miner.hash_rate.value, props.miner.hash_rate.unit);
+  if (!props.state?.hash_rate?.value || !props.miner.hash_rate_max?.value) return 0;
+  const current = normalizeHashRate(props.state.hash_rate.value, props.state.hash_rate.unit);
   const max = normalizeHashRate(props.miner.hash_rate_max.value, props.miner.hash_rate_max.unit);
   if (max === 0) return 0;
   return Math.min((current / max) * 100, 100);
@@ -43,8 +45,8 @@ const hashRatePct = computed(() => {
 
 // Power consumption % of max
 const powerPct = computed(() => {
-  if (!props.miner.power_consumption || !props.miner.power_consumption_max) return 0;
-  return Math.min((props.miner.power_consumption / props.miner.power_consumption_max) * 100, 100);
+  if (!props.state?.power_consumption || !props.miner.power_consumption_max) return 0;
+  return Math.min((props.state.power_consumption / props.miner.power_consumption_max) * 100, 100);
 });
 </script>
 
@@ -91,7 +93,7 @@ const powerPct = computed(() => {
             <PhCpu :size="11" /> Hash
           </span>
           <span class="font-mono" :class="isOn ? 'text-emerald-400' : 'text-base-content/30'">
-            {{ formatHashRate(miner.hash_rate?.value, miner.hash_rate?.unit) }}
+            {{ formatHashRate(state?.hash_rate?.value, state?.hash_rate?.unit) }}
           </span>
         </div>
         <div class="h-1 rounded-full bg-base-300/30 overflow-hidden">
@@ -110,7 +112,7 @@ const powerPct = computed(() => {
             <PhLightning :size="11" /> Power
           </span>
           <span class="font-mono" :class="isOn ? 'text-amber-400' : 'text-base-content/30'">
-            {{ formatPower(miner.power_consumption) }}
+            {{ formatPower(state?.power_consumption) }}
           </span>
         </div>
         <div class="h-1 rounded-full bg-base-300/30 overflow-hidden">

--- a/src/components/minerControllers/MinerControllerCard.vue
+++ b/src/components/minerControllers/MinerControllerCard.vue
@@ -2,6 +2,7 @@
 import type { MinerController, MinerControllerAdapter } from "../../core/models/minerController";
 import type { Miner } from "../../core/models/miner";
 import { useExternalServiceStore } from "../../core/stores/externalServiceStore";
+import { useMinerStore } from "../../core/stores/minerStore";
 import { computed, ref } from "vue";
 import {
   PhPencil,
@@ -30,6 +31,7 @@ const emit = defineEmits<{
 }>();
 
 const externalServiceStore = useExternalServiceStore();
+const minerStore = useMinerStore();
 const showDeleteConfirm = ref(false);
 
 // External service linked
@@ -53,7 +55,10 @@ const activeAssignedMiners = computed(() => {
 });
 
 const runningAssignedMiners = computed(() => {
-  return assignedMiners.value.filter((m) => m.status === "on");
+  return assignedMiners.value.filter((m) => {
+    const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+    return state?.status === "on";
+  });
 });
 
 // Adapter type configuration for styling
@@ -193,7 +198,7 @@ function cancelDelete() {
             v-for="miner in assignedMiners.slice(0, 4)"
             :key="miner.id"
             class="badge badge-sm badge-ghost"
-            :class="{ 'badge-success badge-outline': miner.status === 'on' }"
+            :class="{ 'badge-success badge-outline': miner.id && minerStore.minerStates.get(miner.id)?.status === 'on' }"
           >
             {{ miner.name }}
           </span>

--- a/src/components/miners/MinerCard.vue
+++ b/src/components/miners/MinerCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Miner, MinerStatus } from "../../core/models/miner";
+import type { Miner, MinerStatus, MinerStateSnapshot } from "../../core/models/miner";
 import { useMinerControllerStore } from "../../core/stores/minerControllerStore";
 import { computed, ref, watch } from "vue";
 import {
@@ -23,6 +23,7 @@ import { formatPower, formatHashRate, normalizeHashRate } from "../../core/utils
 
 const props = defineProps<{
   miner: Miner;
+  state?: MinerStateSnapshot;
 }>();
 
 const emit = defineEmits<{
@@ -46,10 +47,13 @@ const minerController = computed(() => {
   );
 });
 
+// Runtime state
+const currentStatus = computed<MinerStatus>(() => props.state?.status ?? 'unknown');
+
 // Status computations
-const isOn = computed(() => props.miner.status === "on");
-const isStarting = computed(() => props.miner.status === "starting");
-const isStopping = computed(() => props.miner.status === "stopping");
+const isOn = computed(() => currentStatus.value === "on");
+const isStarting = computed(() => currentStatus.value === "starting");
+const isStopping = computed(() => currentStatus.value === "stopping");
 const canStart = computed(
   () =>
     props.miner.active &&
@@ -66,7 +70,7 @@ const canStop = computed(
 
 // Reset isProcessing when status changes
 watch(
-  () => props.miner.status,
+  currentStatus,
   (newStatus, oldStatus) => {
     if (newStatus !== oldStatus && isProcessing.value) {
       isProcessing.value = false;
@@ -159,14 +163,14 @@ const statusConfig = computed(() => {
       },
     },
   };
-  return configs[props.miner.status] || configs.unknown;
+  return configs[currentStatus.value] || configs.unknown;
 });
 
 // Hash rate progress (normalize units before comparing)
 const hashRateProgress = computed(() => {
-  if (!props.miner.hash_rate?.value || !props.miner.hash_rate_max?.value)
+  if (!props.state?.hash_rate?.value || !props.miner.hash_rate_max?.value)
     return 0;
-  const current = normalizeHashRate(props.miner.hash_rate.value, props.miner.hash_rate.unit || "TH/s");
+  const current = normalizeHashRate(props.state.hash_rate.value, props.state.hash_rate.unit || "TH/s");
   const max = normalizeHashRate(props.miner.hash_rate_max.value, props.miner.hash_rate_max.unit || "TH/s");
   if (max === 0) return 0;
   return Math.min((current / max) * 100, 100);
@@ -174,10 +178,10 @@ const hashRateProgress = computed(() => {
 
 // Power consumption progress
 const powerProgress = computed(() => {
-  if (!props.miner.power_consumption || !props.miner.power_consumption_max)
+  if (!props.state?.power_consumption || !props.miner.power_consumption_max)
     return 0;
   return Math.min(
-    (props.miner.power_consumption / props.miner.power_consumption_max) * 100,
+    (props.state.power_consumption / props.miner.power_consumption_max) * 100,
     100
   );
 });
@@ -279,7 +283,7 @@ function handleDeactivate() {
             <span>Hash Rate</span>
           </div>
           <div class="text-sm font-medium text-base-content">
-            {{ formatHashRate(miner.hash_rate?.value, miner.hash_rate?.unit) }}
+            {{ formatHashRate(state?.hash_rate?.value, state?.hash_rate?.unit) }}
             <span class="text-base-content/40">
               / {{ formatHashRate(miner.hash_rate_max?.value, miner.hash_rate_max?.unit) }}
             </span>
@@ -299,7 +303,7 @@ function handleDeactivate() {
             <span>Power</span>
           </div>
           <div class="text-sm font-medium text-base-content">
-            {{ formatPower(miner.power_consumption) }}
+            {{ formatPower(state?.power_consumption) }}
             <span class="text-base-content/40">
               / {{ formatPower(miner.power_consumption_max) }}
             </span>

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch, toRaw } from "vue";
-import type { Miner } from "../../core/models/miner";
+import type { Miner, MinerStateSnapshot } from "../../core/models/miner";
 import { useMinerControllerStore } from "../../core/stores/minerControllerStore";
 import { MinerControllerService } from "../../core/services/minerControllerService";
 import {
@@ -34,7 +34,6 @@ const hashRateUnits = ["H/s", "KH/s", "MH/s", "GH/s", "TH/s", "PH/s", "EH/s"];
 // Local form state
 const formData = ref<Miner>({
   name: "",
-  status: "unknown",
   active: false,
   hash_rate_max: { value: 100, unit: "TH/s" },
   power_consumption_max: 3000,
@@ -55,7 +54,6 @@ watch(
       } else {
         formData.value = {
           name: "",
-          status: "unknown",
           active: false,
           hash_rate_max: { value: 100, unit: "TH/s" },
           power_consumption_max: 3000,
@@ -134,13 +132,18 @@ async function fetchMinerDetails() {
   fetchSuccess.value = false;
   highlightedFields.value = new Set();
   try {
-    const details = await minerControllerService.getMinerDetails(controllerId);
+    const snapshot: MinerStateSnapshot = await minerControllerService.getMinerDetails(controllerId);
     const updated = new Set<string>();
-    if (isNonEmpty(details.model)) {
-      updated.add("model");
-      highlightedFields.value = updated;
-      await typewriterEffect((v) => (formData.value.model = v), details.model!);
+    // Auto-fill max values from current runtime readings
+    if (snapshot.hash_rate && snapshot.hash_rate.value > 0) {
+      formData.value.hash_rate_max = { value: snapshot.hash_rate.value, unit: snapshot.hash_rate.unit || "TH/s" };
+      updated.add("hash_rate_max");
     }
+    if (snapshot.power_consumption && snapshot.power_consumption > 0) {
+      formData.value.power_consumption_max = snapshot.power_consumption;
+      updated.add("power_consumption_max");
+    }
+    highlightedFields.value = updated;
     fetchSuccess.value = true;
     setTimeout(() => {
       fetchSuccess.value = false;
@@ -284,7 +287,8 @@ function handleSave() {
                 v-model.number="formData.hash_rate_max!.value"
                 type="number"
                 min="0"
-                class="input input-bordered flex-1"
+                class="input input-bordered flex-1 transition-colors duration-500"
+                :class="{ 'input-success border-success': highlightedFields.has('hash_rate_max') }"
                 placeholder="100"
                 required
               />
@@ -307,7 +311,8 @@ function handleSave() {
                 Max Power Consumption *
               </span>
             </label>
-            <label class="input input-bordered flex items-center gap-2">
+            <label class="input input-bordered flex items-center gap-2 transition-colors duration-500"
+              :class="{ 'input-success border-success': highlightedFields.has('power_consumption_max') }">
               <input
                 v-model.number="formData.power_consumption_max"
                 type="number"

--- a/src/core/composables/useDashboardPolling.ts
+++ b/src/core/composables/useDashboardPolling.ts
@@ -42,10 +42,12 @@ export function useDashboardPolling(intervalMs = 5000) {
   function detectMinerChanges() {
     for (const miner of minerStore.miners) {
       if (!miner.id) continue;
+      const state = minerStore.minerStates.get(miner.id);
+      const currentStatus = state?.status ?? 'unknown';
       const prevStatus = dashboardStore.previousMinerStatuses.get(miner.id);
-      if (prevStatus && prevStatus !== miner.status) {
+      if (prevStatus && prevStatus !== currentStatus) {
         const now = Math.floor(Date.now() / 1000);
-        if (miner.status === "on" && prevStatus !== "on") {
+        if (currentStatus === "on" && prevStatus !== "on") {
           dashboardStore.addEvent({
             type: "miner_start",
             message: `${miner.name} started`,
@@ -56,7 +58,7 @@ export function useDashboardPolling(intervalMs = 5000) {
             minerName: miner.name,
             action: "on",
           });
-        } else if (miner.status === "off" && prevStatus !== "off") {
+        } else if (currentStatus === "off" && prevStatus !== "off") {
           dashboardStore.addEvent({
             type: "miner_stop",
             message: `${miner.name} stopped`,
@@ -70,12 +72,12 @@ export function useDashboardPolling(intervalMs = 5000) {
         } else {
           dashboardStore.addEvent({
             type: "status_change",
-            message: `${miner.name}: ${prevStatus} → ${miner.status}`,
+            message: `${miner.name}: ${prevStatus} → ${currentStatus}`,
             timestamp: new Date(),
           });
         }
       }
-      dashboardStore.previousMinerStatuses.set(miner.id, miner.status);
+      dashboardStore.previousMinerStatuses.set(miner.id, currentStatus);
     }
   }
 
@@ -96,11 +98,12 @@ export function useDashboardPolling(intervalMs = 5000) {
     let totalHash = 0;
     let totalPower = 0;
     for (const m of minerStore.miners) {
-      if (m.status === "on") {
-        if (m.hash_rate?.value) {
-          totalHash += normalizeHashRate(m.hash_rate.value, m.hash_rate.unit || "TH/s");
+      const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+      if (state?.status === "on") {
+        if (state.hash_rate?.value) {
+          totalHash += normalizeHashRate(state.hash_rate.value, state.hash_rate.unit || "TH/s");
         }
-        totalPower += m.power_consumption || 0;
+        totalPower += state.power_consumption || 0;
       }
     }
 
@@ -227,7 +230,8 @@ export function useDashboardPolling(intervalMs = 5000) {
     if (dashboardStore.previousMinerStatuses.size === 0) {
       for (const miner of minerStore.miners) {
         if (miner.id) {
-          dashboardStore.previousMinerStatuses.set(miner.id, miner.status);
+          const state = minerStore.minerStates.get(miner.id);
+          dashboardStore.previousMinerStatuses.set(miner.id, state?.status ?? 'unknown');
         }
       }
     }

--- a/src/core/models/miner.ts
+++ b/src/core/models/miner.ts
@@ -10,11 +10,15 @@ export interface Miner {
   id?: string;
   name: string;
   model?: string;
-  status: MinerStatus;
-  hash_rate?: HashRate;
   hash_rate_max?: HashRate;
-  power_consumption?: number;
   power_consumption_max?: number;
   active: boolean;
   controller_id?: string;
+}
+
+// Runtime operational state
+export interface MinerStateSnapshot {
+  status: MinerStatus;
+  hash_rate?: HashRate;
+  power_consumption?: number;
 }

--- a/src/core/models/policy.ts
+++ b/src/core/models/policy.ts
@@ -1,7 +1,7 @@
 import type { EnergySource, EnergyStateSnapshot } from "./energySource";
 import type { Forecast, Sun } from "./forecast";
 import type { ConsumptionForecast } from "./homeLoad";
-import type { Miner, HashRate } from "./miner";
+import type { Miner, HashRate, MinerStateSnapshot } from "./miner";
 
 export type RuleType = "start" | "stop";
 
@@ -65,5 +65,6 @@ export interface DecisionalContext {
   tracker_current_hashrate?: HashRate;
   sun?: Sun;
   miner?: Miner;
+  miner_state?: MinerStateSnapshot;
   timestamp: string; // ISO datetime
 }

--- a/src/core/services/minerControllerService.ts
+++ b/src/core/services/minerControllerService.ts
@@ -1,6 +1,6 @@
 import { BaseService } from "./baseService";
 import type { MinerController, MinerControllerAdapter, ConfigSchema } from "../models/minerController";
-import type { Miner } from "../models/miner";
+import type { MinerStateSnapshot } from "../models/miner";
 
 export class MinerControllerService extends BaseService {
   getMinerControllers(): Promise<MinerController[]> {
@@ -36,7 +36,7 @@ export class MinerControllerService extends BaseService {
       .then((result) => (result === "null" ? null : result));
   }
 
-  getMinerDetails(controllerId: string): Promise<Miner> {
-    return this.get<Miner>(`/miner-controllers/${controllerId}/miner-details`).getData();
+  getMinerDetails(controllerId: string): Promise<MinerStateSnapshot> {
+    return this.get<MinerStateSnapshot>(`/miner-controllers/${controllerId}/miner-details`).getData();
   }
 }

--- a/src/core/services/minerService.ts
+++ b/src/core/services/minerService.ts
@@ -1,5 +1,5 @@
 import { BaseService } from "./baseService";
-import type { Miner } from "../models/miner";
+import type { Miner, MinerStateSnapshot } from "../models/miner";
 
 export class MinerService extends BaseService {
   getMiners(): Promise<Miner[]> {
@@ -30,8 +30,8 @@ export class MinerService extends BaseService {
     return this.post<Miner>(`/miners/${minerId}/stop`, {}).getData();
   }
 
-  getMinerStatus(minerId: string): Promise<Miner> {
-    return this.get<Miner>(`/miners/${minerId}/status`).getData();
+  getMinerStatus(minerId: string): Promise<MinerStateSnapshot> {
+    return this.get<MinerStateSnapshot>(`/miners/${minerId}/status`).getData();
   }
 
   activateMiner(minerId: string): Promise<Miner> {

--- a/src/core/stores/minerStore.ts
+++ b/src/core/stores/minerStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import type { Miner } from "../models/miner";
+import type { Miner, MinerStateSnapshot } from "../models/miner";
 import { MinerService } from "../services/minerService";
 
 export const useMinerStore = defineStore("miner", () => {
@@ -8,6 +8,7 @@ export const useMinerStore = defineStore("miner", () => {
 
   // State
   const miners = ref<Miner[]>([]);
+  const minerStates = ref<Map<string, MinerStateSnapshot>>(new Map());
 
   // Actions
   function loadMiners() {
@@ -45,20 +46,23 @@ export const useMinerStore = defineStore("miner", () => {
   }
 
   function getMinerStatus(minerId: string) {
-    return service.getMinerStatus(minerId).then((updatedMiner) => {
-      // Update the miner in the array with the new status
-      const index = miners.value.findIndex(m => m.id?.toString() === minerId);
-      if (index !== -1) {
-        // Update properties individually to ensure reactivity
-        Object.assign(miners.value[index], updatedMiner);
-      }
-      return updatedMiner;
+    return service.getMinerStatus(minerId).then((snapshot) => {
+      // Store the runtime state snapshot in the map
+      const newMap = new Map(minerStates.value);
+      newMap.set(minerId, snapshot);
+      minerStates.value = newMap;
+      return snapshot;
     });
+  }
+
+  function getMinerState(minerId: string): MinerStateSnapshot | undefined {
+    return minerStates.value.get(minerId);
   }
 
   return {
     //STATE
     miners,
+    minerStates,
     // ACTIONS
     loadMiners,
     addMiner,
@@ -69,5 +73,6 @@ export const useMinerStore = defineStore("miner", () => {
     activateMiner,
     deactivateMiner,
     getMinerStatus,
+    getMinerState,
   };
 });

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -47,7 +47,10 @@ const { lastUpdated, isPolling, events, hashRateSeries, powerSeries, energyProdu
 const totalMiners = computed(() => minerStore.miners.length);
 
 const runningMiners = computed(
-  () => minerStore.miners.filter((m) => m.status === "on").length
+  () => minerStore.miners.filter((m) => {
+    const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+    return state?.status === "on";
+  }).length
 );
 
 const activeMiners = computed(
@@ -57,8 +60,9 @@ const activeMiners = computed(
 const totalHashRate = computed(() => {
   let total = 0;
   for (const m of minerStore.miners) {
-    if (m.status === "on" && m.hash_rate?.value) {
-      total += normalizeHashRate(m.hash_rate.value, m.hash_rate.unit || "TH/s");
+    const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+    if (state?.status === "on" && state.hash_rate?.value) {
+      total += normalizeHashRate(state.hash_rate.value, state.hash_rate.unit || "TH/s");
     }
   }
   return total;
@@ -73,8 +77,14 @@ const formattedHashRate = computed(() => {
 
 const totalPowerConsumption = computed(() => {
   return minerStore.miners
-    .filter((m) => m.status === "on")
-    .reduce((sum, m) => sum + (m.power_consumption || 0), 0);
+    .filter((m) => {
+      const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+      return state?.status === "on";
+    })
+    .reduce((sum, m) => {
+      const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+      return sum + (state?.power_consumption || 0);
+    }, 0);
 });
 
 const enabledUnits = computed(
@@ -465,6 +475,7 @@ const forecastIntervalData = computed<ForecastIntervalData[]>(() => {
               v-for="miner in minerStore.miners"
               :key="miner.id"
               :miner="miner"
+              :state="miner.id ? minerStore.minerStates.get(miner.id) : undefined"
             />
             <div
               v-if="minerStore.miners.length === 0"

--- a/src/views/settings/MinersSettingsView.vue
+++ b/src/views/settings/MinersSettingsView.vue
@@ -39,6 +39,12 @@ const statusFilters = [
 
 let statusInterval: number | undefined;
 
+// Helper to get miner status from the state map
+function getMinerStatus(miner: Miner): MinerStatus {
+  if (!miner.id) return "unknown";
+  return minerStore.minerStates.get(miner.id)?.status ?? "unknown";
+}
+
 // Computed
 const filteredMiners = computed(() => {
   if (selectedStatusFilter.value === "all") {
@@ -47,37 +53,42 @@ const filteredMiners = computed(() => {
   if (selectedStatusFilter.value === "active") {
     return minerStore.miners.filter((m) => m.active);
   }
-  return minerStore.miners.filter((m) => m.status === selectedStatusFilter.value);
+  return minerStore.miners.filter((m) => getMinerStatus(m) === selectedStatusFilter.value);
 });
 
 const stats = computed(() => {
   const miners = minerStore.miners;
   const totalMiners = miners.length;
   const activeMiners = miners.filter((m) => m.active).length;
-  const runningMiners = miners.filter((m) => m.status === "on").length;
+  const runningMiners = miners.filter((m) => getMinerStatus(m) === "on").length;
 
   // Calculate current total hash rate (only from running miners)
-  const runningMinersData = miners.filter((m) => m.status === "on");
+  const runningMinersData = miners.filter((m) => getMinerStatus(m) === "on");
   let totalHashRate = 0;
   let hashRateUnit = "TH/s";
 
   runningMinersData.forEach((m) => {
-    if (m.hash_rate?.value) {
+    const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+    if (state?.hash_rate?.value) {
       // Normalize to TH/s for aggregation
-      const normalized = normalizeHashRate(m.hash_rate.value, m.hash_rate.unit || "TH/s");
+      const normalized = normalizeHashRate(state.hash_rate.value, state.hash_rate.unit || "TH/s");
       totalHashRate += normalized;
     }
   });
 
   // Calculate total power consumption
   const totalPowerConsumption = runningMinersData.reduce(
-    (sum, m) => sum + (m.power_consumption || 0),
+    (sum, m) => {
+      const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+      return sum + (state?.power_consumption || 0);
+    },
     0
   );
 
   // Status counts
   const statusCounts = miners.reduce((acc, m) => {
-    acc[m.status] = (acc[m.status] || 0) + 1;
+    const status = getMinerStatus(m);
+    acc[status] = (acc[status] || 0) + 1;
     return acc;
   }, {} as Record<string, number>);
 
@@ -298,6 +309,7 @@ function getFilterCount(filter: string): number {
             v-for="miner in filteredMiners"
             :key="miner.id"
             :miner="miner"
+            :state="miner.id ? minerStore.minerStates.get(miner.id) : undefined"
             @edit="handleEdit"
             @delete="handleDelete"
             @start="handleStart"


### PR DESCRIPTION
Adapts the frontend to the backend refactoring that separated the `Miner` entity into **static configuration** and **runtime state** (`MinerStateSnapshot`), following the Single Responsibility Principle.(https://github.com/edge-mining/core/pull/78).

- **`Miner`** — static configuration only: `name`, `model`, `hash_rate_max`, `power_consumption_max`, `active`, `controller_id`
- **`MinerStateSnapshot`** — transient runtime state: `status`, `hash_rate`, `power_consumption`

Runtime state is no longer embedded in the `Miner` object. Instead, it is fetched on-demand via `/miners/{id}/status` and stored in a dedicated reactive `Map<string, MinerStateSnapshot>` in the Pinia store.

## Motivation

The backend removed `status`, `hash_rate`, and `power_consumption` from the `Miner` entity and introduced `MinerStateSnapshot` as a separate value object returned by the status endpoint. The frontend needed to mirror this separation to:

1. Avoid type mismatches with API responses
2. Cleanly separate static config (persisted) from runtime data (polled)
3. Enable independent update cadences — config changes are rare, status polling is frequent

## Changes by Layer

### Model

| File | Change |
|------|--------|
| `src/core/models/miner.ts` | Removed `status`, `hash_rate`, `power_consumption` from `Miner`; added `MinerStateSnapshot` interface |
| `src/core/models/policy.ts` | Added `miner_state?: MinerStateSnapshot` to `DecisionalContext` |

### Service

| File | Change |
|------|--------|
| `src/core/services/minerService.ts` | `getMinerStatus()` return type → `MinerStateSnapshot` |
| `src/core/services/minerControllerService.ts` | `getMinerDetails()` return type → `MinerStateSnapshot` |

### Store

| File | Change |
|------|--------|
| `src/core/stores/minerStore.ts` | Added `minerStates` reactive `Map<string, MinerStateSnapshot>`; `getMinerStatus()` populates the map instead of mutating the `Miner` object; added `getMinerState()` helper |

### Settings Components

| File | Change |
|------|--------|
| `src/components/miners/MinerCard.vue` | Added `state?: MinerStateSnapshot` prop; all runtime reads (`status`, `hash_rate`, `power_consumption`) sourced from `state` |
| `src/components/miners/MinerFormModal.vue` | Removed `status` from form defaults; `fetchMinerDetails` now receives `MinerStateSnapshot` and auto-fills `hash_rate_max`/`power_consumption_max` from runtime readings |
| `src/views/settings/MinersSettingsView.vue` | Filters and stats computed from `minerStore.minerStates`; passes `state` prop to `MinerCard` |
| `src/components/minerControllers/MinerControllerCard.vue` | Uses `minerStore.minerStates` for running-miner detection and badge styling |

### Dashboard Components

| File | Change |
|------|--------|
| `src/components/dashboard/MinerTile.vue` | Added `state?: MinerStateSnapshot` prop; status, hash rate, and power display read from `state` |
| `src/views/DashboardView.vue` | KPI computations (`runningMiners`, `totalHashRate`, `totalPowerConsumption`) read from `minerStore.minerStates`; passes `state` prop to `MinerTile` |
| `src/core/composables/useDashboardPolling.ts` | `detectMinerChanges()`, `recordSnapshot()`, and `initLoad()` read status from `minerStore.minerStates` instead of `miner.status` |

## Breaking Changes

1. **`Miner` interface** no longer contains `status`, `hash_rate`, or `power_consumption`
2. **Components** (`MinerCard`, `MinerTile`) now require a `state` prop for runtime data display
3. **`getMinerStatus()`** returns `MinerStateSnapshot` instead of `Miner`
4. **`getMinerDetails()`** (MinerControllerService) returns `MinerStateSnapshot` instead of `Miner`

## How It Works

```
┌──────────────┐     GET /miners          ┌──────────────────┐
│  API Server  │ ◄──────────────────────  │   minerStore     │
│              │     → Miner[]            │                  │
│              │                          │  miners: Miner[] │
│              │     GET /miners/:id/     │  minerStates:    │
│              │         status           │   Map<id,        │
│              │ ◄──────────────────────  │   Snapshot>      │
│              │     → MinerStateSnapshot │                  │
└──────────────┘                          └──────┬───────────┘
                                                 │
                                    ┌────────────┼────────────┐
                                    │            │            │
                              ┌─────▼───┐  ┌─────▼───┐  ┌─────▼──────┐
                              │MinerCard│  │MinerTile│  │ Dashboard  │
                              │:miner   │  │:miner   │  │ KPIs       │
                              │:state   │  │:state   │  │            │
                              └─────────┘  └─────────┘  └────────────┘
```

## Validation

- `vue-tsc --noEmit` passes with zero errors
- All components receive correct props at usage sites
- Polling loop continues to work: status is fetched → stored in `minerStates` → components react via Vue's reactivity system
