### PR TITLE
Multiple miner controller support (feature-based architecture)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "0.1.0-rev1",
+  "version": "0.1.0-rev2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/dashboard/TempFanChart.vue
+++ b/src/components/dashboard/TempFanChart.vue
@@ -1,0 +1,248 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import VueApexCharts from "vue3-apexcharts";
+import type { TimeSeriesPoint } from "../../core/composables/useDashboardPolling";
+
+const props = withDefaults(
+  defineProps<{
+    chipTempData: TimeSeriesPoint[];
+    boardTempData: TimeSeriesPoint[];
+    internalFanData: TimeSeriesPoint[];
+    externalFanData: TimeSeriesPoint[];
+    height?: number | string;
+    chipTempColor?: string;
+    boardTempColor?: string;
+    internalFanColor?: string;
+    externalFanColor?: string;
+    range?: number;
+  }>(),
+  {
+    height: 160,
+    chipTempColor: "rgba(248, 113, 113, 0.9)",
+    boardTempColor: "rgba(251, 146, 60, 0.9)",
+    internalFanColor: "rgba(56, 189, 248, 0.9)",
+    externalFanColor: "rgba(129, 140, 248, 0.9)",
+    range: 10 * 60 * 1000,
+  }
+);
+
+const hasTemp = computed(() => props.chipTempData.length > 0 || props.boardTempData.length > 0);
+const hasFan = computed(() => props.internalFanData.length > 0 || props.externalFanData.length > 0);
+const dualAxis = computed(() => hasTemp.value && hasFan.value);
+
+interface SeriesEntry {
+  name: string;
+  data: { x: number; y: number }[];
+  kind: "temp" | "fan";
+  color: string;
+}
+
+const activeSeries = computed<SeriesEntry[]>(() => {
+  const result: SeriesEntry[] = [];
+  if (props.chipTempData.length > 0) {
+    result.push({
+      name: "Chip Temp",
+      data: props.chipTempData.map((p) => ({ x: p.time * 1000, y: p.value })),
+      kind: "temp",
+      color: props.chipTempColor,
+    });
+  }
+  if (props.boardTempData.length > 0) {
+    result.push({
+      name: "Board Temp",
+      data: props.boardTempData.map((p) => ({ x: p.time * 1000, y: p.value })),
+      kind: "temp",
+      color: props.boardTempColor,
+    });
+  }
+  if (props.internalFanData.length > 0) {
+    result.push({
+      name: "Internal Fan",
+      data: props.internalFanData.map((p) => ({ x: p.time * 1000, y: p.value })),
+      kind: "fan",
+      color: props.internalFanColor,
+    });
+  }
+  if (props.externalFanData.length > 0) {
+    result.push({
+      name: "External Fan",
+      data: props.externalFanData.map((p) => ({ x: p.time * 1000, y: p.value })),
+      kind: "fan",
+      color: props.externalFanColor,
+    });
+  }
+  return result;
+});
+
+const series = computed(() =>
+  activeSeries.value.map((s) => ({ name: s.name, data: s.data }))
+);
+
+const colors = computed(() => activeSeries.value.map((s) => s.color));
+
+function formatTemp(v: number): string {
+  return `${v.toFixed(1)} °C`;
+}
+
+function formatFan(v: number): string {
+  return `${Math.round(v)} RPM`;
+}
+
+// Build one yaxis entry per series so ApexCharts maps them correctly.
+// Duplicate axes on the same side get show:false to avoid label clutter.
+const yaxisConfig = computed(() => {
+  if (activeSeries.value.length === 0) return {};
+  if (!dualAxis.value) {
+    // Single axis mode: all series share one axis
+    const isTempOnly = hasTemp.value;
+    return activeSeries.value.map((_, i) => ({
+      show: i === 0,
+      seriesName: activeSeries.value[0].name,
+      decimalsInFloat: isTempOnly ? 1 : 0,
+      labels: {
+        show: i === 0,
+        style: { colors: "rgba(255,255,255,0.3)", fontSize: "10px" },
+        formatter: isTempOnly ? formatTemp : formatFan,
+      },
+      title: { text: undefined },
+    }));
+  }
+
+  // Dual axis mode: temp on left, fan on right
+  let tempPrimaryName: string | undefined;
+  let fanPrimaryName: string | undefined;
+
+  return activeSeries.value.map((s) => {
+    if (s.kind === "temp") {
+      const isFirst = !tempPrimaryName;
+      if (isFirst) tempPrimaryName = s.name;
+      return {
+        show: isFirst,
+        seriesName: tempPrimaryName,
+        opposite: false,
+        decimalsInFloat: 1,
+        labels: {
+          show: isFirst,
+          style: { colors: "rgba(255,255,255,0.3)", fontSize: "10px" },
+          formatter: formatTemp,
+        },
+        title: { text: undefined },
+      };
+    } else {
+      const isFirst = !fanPrimaryName;
+      if (isFirst) fanPrimaryName = s.name;
+      return {
+        show: isFirst,
+        seriesName: fanPrimaryName,
+        opposite: true,
+        decimalsInFloat: 0,
+        labels: {
+          show: isFirst,
+          style: { colors: "rgba(255,255,255,0.3)", fontSize: "10px" },
+          formatter: formatFan,
+        },
+        title: { text: undefined },
+      };
+    }
+  });
+});
+
+const chartOptions = computed(() => {
+  // Force re-compute on data changes
+  void props.chipTempData;
+  void props.boardTempData;
+  void props.internalFanData;
+  void props.externalFanData;
+
+  return {
+    chart: {
+      id: "temp-fan-chart",
+      type: "line" as const,
+      height: props.height,
+      toolbar: { show: false },
+      zoom: { enabled: false },
+      animations: {
+        enabled: true,
+        easing: "linear" as const,
+        dynamicAnimation: { enabled: true, speed: 1000 },
+      },
+      background: "transparent",
+      fontFamily: "inherit",
+      selection: { enabled: false },
+    },
+    stroke: {
+      curve: "smooth" as const,
+      width: 2,
+    },
+    fill: { opacity: 0 },
+    colors: colors.value,
+    grid: {
+      borderColor: "rgba(255,255,255,0.04)",
+      strokeDashArray: 3,
+      xaxis: { lines: { show: true } },
+      yaxis: { lines: { show: true } },
+      padding: { left: 4, right: 4, top: 0, bottom: 0 },
+    },
+    xaxis: {
+      type: "datetime" as const,
+      range: props.range,
+      labels: {
+        show: true,
+        style: { colors: "rgba(255,255,255,0.3)", fontSize: "10px" },
+        datetimeFormatter: { hour: "HH:mm", minute: "HH:mm" },
+      },
+      axisBorder: { show: false },
+      axisTicks: { show: false },
+      tooltip: { enabled: false },
+    },
+    yaxis: yaxisConfig.value,
+    dataLabels: { enabled: false },
+    tooltip: {
+      enabled: true,
+      shared: true,
+      intersect: false,
+      followCursor: true,
+      theme: "dark" as const,
+      x: { show: true, format: "HH:mm:ss" },
+      y: {
+        formatter: (v: number, opts?: { seriesIndex?: number }) => {
+          if (opts?.seriesIndex != null) {
+            const s = activeSeries.value[opts.seriesIndex];
+            return s?.kind === "fan" ? formatFan(v) : formatTemp(v);
+          }
+          return formatTemp(v);
+        },
+      },
+      marker: { show: true },
+    },
+    legend: {
+      show: true,
+      position: "top" as const,
+      horizontalAlign: "right" as const,
+      fontSize: "10px",
+      labels: { colors: "rgba(255,255,255,0.5)" },
+      markers: { size: 6, shape: "circle" as const },
+      itemMargin: { horizontal: 8 },
+    },
+    markers: {
+      size: 0,
+      colors: colors.value,
+      strokeColors: "#fff",
+      strokeWidth: 1,
+      hover: { size: 4, sizeOffset: 2 },
+    },
+  };
+});
+</script>
+
+<template>
+  <div class="temp-fan-chart-wrapper">
+    <VueApexCharts
+      type="line"
+      :height="height === '100%' ? '100%' : height"
+      :width="'100%'"
+      :options="chartOptions"
+      :series="series"
+    />
+  </div>
+</template>

--- a/src/components/minerControllers/MinerControllerCard.vue
+++ b/src/components/minerControllers/MinerControllerCard.vue
@@ -46,7 +46,7 @@ const externalService = computed(() => {
 const assignedMiners = computed(() => {
   if (!props.allMiners || !props.minerController.id) return [];
   return props.allMiners.filter(
-    (miner) => miner.controller_id === props.minerController.id
+    (miner) => miner.controller_ids?.includes(props.minerController.id!)
   );
 });
 

--- a/src/components/miners/MinerCard.vue
+++ b/src/components/miners/MinerCard.vue
@@ -40,12 +40,14 @@ const minerControllerStore = useMinerControllerStore();
 const showDeleteConfirm = ref(false);
 const isProcessing = ref(false);
 
-const minerController = computed(() => {
-  if (!props.miner.controller_id) return null;
-  return minerControllerStore.minerControllers.find(
-    (mc) => mc.id === props.miner.controller_id
+const minerControllers = computed(() => {
+  if (!props.miner.controller_ids?.length) return [];
+  return minerControllerStore.minerControllers.filter(
+    (mc) => props.miner.controller_ids!.includes(mc.id!)
   );
 });
+
+const hasController = computed(() => minerControllers.value.length > 0);
 
 // Runtime state
 const currentStatus = computed<MinerStatus>(() => props.state?.status ?? 'unknown');
@@ -321,16 +323,16 @@ function handleDeactivate() {
     <template #footer>
       <div class="flex items-center gap-2">
         <!-- Controller -->
-        <div v-if="minerController" class="flex items-center gap-2 min-w-0 flex-shrink">
+        <div v-if="minerControllers.length" class="flex items-center gap-2 min-w-0 flex-shrink">
           <div class="h-6 w-6 rounded-full bg-info/20 flex items-center justify-center">
             <PhGear :size="14" class="text-info" />
           </div>
           <div>
             <div class="text-[10px] uppercase tracking-wider text-base-content/40">
-              Controller
+              {{ minerControllers.length === 1 ? 'Controller' : 'Controllers' }}
             </div>
             <div class="text-sm text-base-content/80 leading-tight truncate max-w-[120px] sm:max-w-none">
-              {{ minerController.name }}
+              {{ minerControllers.map(mc => mc.name).join(', ') }}
             </div>
           </div>
         </div>
@@ -353,15 +355,15 @@ function handleDeactivate() {
             <!-- Start/Stop/Refresh -->
             <div class="join">
               <button class="btn btn-xs join-item" :class="canStart ? 'btn-success' : 'btn-ghost opacity-40'"
-                :disabled="!canStart || !minerController" @click="handleStart" title="Start">
+                :disabled="!canStart || !hasController" @click="handleStart" title="Start">
                 <PhPlay :size="14" />
               </button>
               <button class="btn btn-xs join-item" :class="canStop ? 'btn-warning' : 'btn-ghost opacity-40'"
-                :disabled="!canStop || !minerController" @click="handleStop" title="Stop">
+                :disabled="!canStop || !hasController" @click="handleStop" title="Stop">
                 <PhStop :size="14" />
               </button>
               <button class="btn btn-xs btn-info join-item" 
-                :disabled="!minerController" @click="handleRefresh" title="Refresh">
+                :disabled="!hasController" @click="handleRefresh" title="Refresh">
                 <PhArrowClockwise :size="14" />
               </button>
             </div>

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -11,6 +11,8 @@ import {
   PhGear,
   PhDownloadSimple,
   PhCheck,
+  PhPlus,
+  PhTrash,
 } from "@phosphor-icons/vue";
 
 const props = defineProps<{
@@ -22,7 +24,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   close: [];
-  save: [miner: Miner];
+  save: [miner: Miner, controllerChanges: { add: string[]; remove: string[] }];
 }>();
 
 const minerControllerStore = useMinerControllerStore();
@@ -39,6 +41,10 @@ const formData = ref<Miner>({
   power_consumption_max: 3000,
 });
 
+// Controller binding state (managed separately from miner data)
+const selectedControllerIds = ref<string[]>([]);
+const originalControllerIds = ref<string[]>([]);
+
 // Watch for changes in the prop to reset form
 watch(
   () => props.open,
@@ -51,6 +57,8 @@ watch(
             ? { ...props.miner.hash_rate_max }
             : { value: 100, unit: "TH/s" },
         };
+        selectedControllerIds.value = [...(props.miner.controller_ids ?? [])];
+        originalControllerIds.value = [...(props.miner.controller_ids ?? [])];
       } else {
         formData.value = {
           name: "",
@@ -58,29 +66,49 @@ watch(
           hash_rate_max: { value: 100, unit: "TH/s" },
           power_consumption_max: 3000,
         };
+        selectedControllerIds.value = [];
+        originalControllerIds.value = [];
       }
     }
   },
   { immediate: true }
 );
 
-// Compute the controller IDs already assigned to other miners
-const assignedControllerIds = computed(() => {
-  if (!props.allMiners) return new Set<string>();
-  return new Set(
-    props.allMiners
-      .filter((m) => m.id !== formData.value.id && m.controller_id)
-      .map((m) => String(m.controller_id))
+// Available controllers not yet selected
+const availableControllers = computed(() => {
+  return minerControllerStore.minerControllers.filter(
+    (controller) => !selectedControllerIds.value.includes(controller.id!)
   );
 });
 
-// Filter available controllers
-const availableControllers = computed(() => {
-  return minerControllerStore.minerControllers.filter(
-    (controller) =>
-      !assignedControllerIds.value.has(controller.id!) ||
-      controller.id === formData.value.controller_id
+// Controller ID being added from the dropdown
+const controllerToAdd = ref<string | undefined>(undefined);
+
+function addController() {
+  if (controllerToAdd.value && !selectedControllerIds.value.includes(controllerToAdd.value)) {
+    selectedControllerIds.value.push(controllerToAdd.value);
+    controllerToAdd.value = undefined;
+  }
+}
+
+function removeController(controllerId: string) {
+  selectedControllerIds.value = selectedControllerIds.value.filter((id) => id !== controllerId);
+}
+
+function getControllerName(controllerId: string): string {
+  const controller = minerControllerStore.minerControllers.find((mc) => mc.id === controllerId);
+  return controller?.name ?? controllerId;
+}
+
+// Compute controller changes (diff)
+const controllerChanges = computed(() => {
+  const add = selectedControllerIds.value.filter(
+    (id) => !originalControllerIds.value.includes(id)
   );
+  const remove = originalControllerIds.value.filter(
+    (id) => !selectedControllerIds.value.includes(id)
+  );
+  return { add, remove };
 });
 
 const isFormValid = computed(() => {
@@ -101,32 +129,11 @@ const isFetchingDetails = ref(false);
 const fetchSuccess = ref(false);
 const fetchError = ref<string | null>(null);
 const highlightedFields = ref<Set<string>>(new Set());
+const fetchControllerId = ref<string | undefined>(undefined);
 
-function isNonEmpty(value: any): boolean {
-  return value !== null && value !== undefined && value !== "";
-}
-
-function typewriterEffect(
-  target: (char: string) => void,
-  text: string,
-  speed = 30
-): Promise<void> {
-  return new Promise((resolve) => {
-    target("");
-    let i = 0;
-    const interval = setInterval(() => {
-      target(text.slice(0, ++i));
-      if (i >= text.length) {
-        clearInterval(interval);
-        resolve();
-      }
-    }, speed);
-  });
-}
-
-async function fetchMinerDetails() {
-  const controllerId = formData.value.controller_id;
+async function fetchMinerDetails(controllerId: string) {
   if (!controllerId) return;
+  fetchControllerId.value = controllerId;
   isFetchingDetails.value = true;
   fetchError.value = null;
   fetchSuccess.value = false;
@@ -148,6 +155,7 @@ async function fetchMinerDetails() {
     setTimeout(() => {
       fetchSuccess.value = false;
       highlightedFields.value = new Set();
+      fetchControllerId.value = undefined;
     }, 3000);
   } catch (error: any) {
     fetchError.value = error?.response?.data?.detail || error?.message || "Failed to fetch miner details from controller";
@@ -160,7 +168,10 @@ function handleSave() {
   if (isFormValid.value) {
     // Deep clone to remove Vue reactive proxies
     const rawData = JSON.parse(JSON.stringify(toRaw(formData.value)));
-    emit("save", rawData);
+    // Remove controller-related fields from miner payload (backend no longer accepts them)
+    delete rawData.features;
+    delete rawData.controller_ids;
+    emit("save", rawData, { ...controllerChanges.value });
   }
 }
 </script>
@@ -219,24 +230,57 @@ function handleSave() {
           </div>
         </div>
 
-        <!-- Controller -->
+        <!-- Controllers -->
         <div class="divider text-xs text-base-content/50 my-4">
-          CONTROLLER
+          CONTROLLERS
         </div>
 
         <div class="form-control">
           <label class="label mb-1">
             <span class="label-text flex items-center gap-2">
               <PhGear :size="16" class="text-info" />
-              Miner Controller
+              Miner Controllers
             </span>
           </label>
+
+          <!-- Selected controllers list -->
+          <div v-if="selectedControllerIds.length > 0" class="space-y-2 mb-3">
+            <div
+              v-for="controllerId in selectedControllerIds"
+              :key="controllerId"
+              class="flex items-center gap-2 bg-base-200/40 rounded-lg px-3 py-2"
+            >
+              <PhGear :size="14" class="text-info flex-shrink-0" />
+              <span class="text-sm text-base-content flex-1 truncate">{{ getControllerName(controllerId) }}</span>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-square"
+                :class="fetchControllerId === controllerId && fetchSuccess ? 'text-success' : 'text-primary'"
+                :disabled="isFetchingDetails"
+                @click="fetchMinerDetails(controllerId)"
+                title="Fetch Miner Details"
+              >
+                <PhCheck v-if="fetchControllerId === controllerId && fetchSuccess" :size="14" />
+                <PhDownloadSimple v-else :size="14" :class="{ 'animate-bounce': isFetchingDetails && fetchControllerId === controllerId }" />
+              </button>
+              <button
+                type="button"
+                class="btn btn-ghost btn-xs btn-square text-error"
+                @click="removeController(controllerId)"
+                title="Remove controller"
+              >
+                <PhTrash :size="14" />
+              </button>
+            </div>
+          </div>
+
+          <!-- Add controller row -->
           <div class="flex gap-2">
             <select
-              v-model="formData.controller_id"
+              v-model="controllerToAdd"
               class="select select-bordered flex-1"
             >
-              <option :value="undefined">None</option>
+              <option :value="undefined">Select a controller to add...</option>
               <option
                 v-for="controller in availableControllers"
                 :key="controller.id"
@@ -247,19 +291,17 @@ function handleSave() {
             </select>
             <button
               type="button"
-              class="btn btn-outline"
-              :class="fetchSuccess ? 'btn-success' : 'btn-primary'"
-              :disabled="!formData.controller_id || isFetchingDetails"
-              @click="fetchMinerDetails"
-              title="Fetch Miner Details"
+              class="btn btn-outline btn-primary"
+              :disabled="!controllerToAdd"
+              @click="addController"
+              title="Add Controller"
             >
-              <PhCheck v-if="fetchSuccess" :size="18" />
-              <PhDownloadSimple v-else :size="18" :class="{ 'animate-bounce': isFetchingDetails }" />
+              <PhPlus :size="18" />
             </button>
           </div>
           <label class="label mt-1">
             <span class="label-text-alt text-base-content/50">
-              Controllers manage remote start/stop operations
+              Controllers provide monitoring and control capabilities
             </span>
           </label>
           <div v-if="fetchError" class="alert alert-error alert-sm mt-2 py-2 text-sm">

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -74,10 +74,22 @@ watch(
   { immediate: true }
 );
 
-// Available controllers not yet selected
+// Controller IDs already assigned to other miners
+const assignedControllerIds = computed(() => {
+  if (!props.allMiners) return new Set<string>();
+  return new Set(
+    props.allMiners
+      .filter((m) => m.id !== formData.value.id)
+      .flatMap((m) => m.controller_ids ?? [])
+  );
+});
+
+// Available controllers: not yet selected for this miner AND not assigned to other miners
 const availableControllers = computed(() => {
   return minerControllerStore.minerControllers.filter(
-    (controller) => !selectedControllerIds.value.includes(controller.id!)
+    (controller) =>
+      !selectedControllerIds.value.includes(controller.id!) &&
+      !assignedControllerIds.value.has(controller.id!)
   );
 });
 

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch, toRaw } from "vue";
-import type { Miner, MinerStateSnapshot } from "../../core/models/miner";
+import { MinerFeatureType, type Miner, type MinerStateSnapshot } from "../../core/models/miner";
 import { useMinerControllerStore } from "../../core/stores/minerControllerStore";
 import { MinerControllerService } from "../../core/services/minerControllerService";
 import {
@@ -137,42 +137,67 @@ function handleClose() {
   emit("close");
 }
 
-const isFetchingDetails = ref(false);
-const fetchSuccess = ref(false);
 const fetchError = ref<string | null>(null);
 const highlightedFields = ref<Set<string>>(new Set());
-const fetchControllerId = ref<string | undefined>(undefined);
 
-async function fetchMinerDetails(controllerId: string) {
-  if (!controllerId) return;
-  fetchControllerId.value = controllerId;
-  isFetchingDetails.value = true;
+// Per-field fetch state
+const fieldFetching = ref<Record<string, boolean>>({});
+const fieldFetchSuccess = ref<Record<string, boolean>>({});
+
+// Resolve which selected controllers provide a given feature type (from miner.features)
+function controllersForFeature(featureType: MinerFeatureType): string[] {
+  if (!props.miner?.features) return [];
+  const seen = new Set<string>();
+  return props.miner.features
+    .filter(
+      (f) =>
+        f.feature_type === featureType &&
+        f.enabled &&
+        selectedControllerIds.value.includes(f.controller_id)
+    )
+    .sort((a, b) => b.priority - a.priority)
+    .map((f) => f.controller_id)
+    .filter((id) => {
+      if (seen.has(id)) return false;
+      seen.add(id);
+      return true;
+    });
+}
+
+const modelControllers = computed(() => controllersForFeature(MinerFeatureType.MODEL_DETECTION));
+const hashRateControllers = computed(() => controllersForFeature(MinerFeatureType.HASHRATE_MONITORING));
+const powerControllers = computed(() => controllersForFeature(MinerFeatureType.POWER_MONITORING));
+
+async function fetchField(field: string, controllerId: string) {
+  fieldFetching.value = { ...fieldFetching.value, [field]: true };
+  fieldFetchSuccess.value = { ...fieldFetchSuccess.value, [field]: false };
   fetchError.value = null;
-  fetchSuccess.value = false;
-  highlightedFields.value = new Set();
   try {
     const snapshot: MinerStateSnapshot = await minerControllerService.getMinerDetails(controllerId);
-    const updated = new Set<string>();
-    // Auto-fill max values from current runtime readings
-    if (snapshot.hash_rate && snapshot.hash_rate.value > 0) {
-      formData.value.hash_rate_max = { value: snapshot.hash_rate.value, unit: snapshot.hash_rate.unit || "TH/s" };
-      updated.add("hash_rate_max");
-    }
-    if (snapshot.power_consumption && snapshot.power_consumption > 0) {
+    let updated = false;
+    if (field === "hash_rate_max" && snapshot.hash_rate && snapshot.hash_rate.value > 0) {
+      formData.value.hash_rate_max = {
+        value: snapshot.hash_rate.value,
+        unit: snapshot.hash_rate.unit || "TH/s",
+      };
+      updated = true;
+    } else if (field === "power_consumption_max" && snapshot.power_consumption && snapshot.power_consumption > 0) {
       formData.value.power_consumption_max = snapshot.power_consumption;
-      updated.add("power_consumption_max");
+      updated = true;
     }
-    highlightedFields.value = updated;
-    fetchSuccess.value = true;
-    setTimeout(() => {
-      fetchSuccess.value = false;
-      highlightedFields.value = new Set();
-      fetchControllerId.value = undefined;
-    }, 3000);
+    if (updated) {
+      highlightedFields.value = new Set([field]);
+      fieldFetchSuccess.value = { ...fieldFetchSuccess.value, [field]: true };
+      setTimeout(() => {
+        fieldFetchSuccess.value = { ...fieldFetchSuccess.value, [field]: false };
+        highlightedFields.value = new Set();
+      }, 3000);
+    }
   } catch (error: any) {
-    fetchError.value = error?.response?.data?.detail || error?.message || "Failed to fetch miner details from controller";
+    fetchError.value =
+      error?.response?.data?.detail || error?.message || "Failed to fetch from controller";
   } finally {
-    isFetchingDetails.value = false;
+    fieldFetching.value = { ...fieldFetching.value, [field]: false };
   }
 }
 
@@ -232,13 +257,40 @@ function handleSave() {
             <label class="label mb-1">
               <span class="label-text font-medium">Model</span>
             </label>
-            <input
-              v-model="formData.model"
-              type="text"
-              placeholder="e.g., Antminer S19 Pro"
-              class="input input-bordered w-full transition-colors duration-500"
-              :class="{ 'input-success border-success': highlightedFields.has('model') }"
-            />
+            <div class="flex gap-2">
+              <input
+                v-model="formData.model"
+                type="text"
+                placeholder="e.g., Antminer S19 Pro"
+                class="input input-bordered w-full flex-1 transition-colors duration-500"
+                :class="{ 'input-success border-success': highlightedFields.has('model') }"
+              />
+              <!-- Fetch Model: single controller -->
+              <button
+                v-if="modelControllers.length === 1"
+                type="button"
+                class="btn btn-sm btn-square"
+                :class="fieldFetchSuccess['model'] ? 'btn-success' : 'btn-ghost'"
+                :disabled="fieldFetching['model']"
+                @click="fetchField('model', modelControllers[0])"
+                :title="`Fetch from ${getControllerName(modelControllers[0])}`"
+              >
+                <PhCheck v-if="fieldFetchSuccess['model']" :size="16" />
+                <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['model'] }" />
+              </button>
+              <!-- Fetch Model: multiple controllers -->
+              <div v-else-if="modelControllers.length > 1" class="dropdown dropdown-end">
+                <label tabindex="0" class="btn btn-sm btn-square" :class="fieldFetchSuccess['model'] ? 'btn-success' : 'btn-ghost'">
+                  <PhCheck v-if="fieldFetchSuccess['model']" :size="16" />
+                  <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['model'] }" />
+                </label>
+                <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
+                  <li v-for="cid in modelControllers" :key="cid">
+                    <a @click="fetchField('model', cid)">{{ getControllerName(cid) }}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -264,17 +316,6 @@ function handleSave() {
             >
               <PhGear :size="14" class="text-info flex-shrink-0" />
               <span class="text-sm text-base-content flex-1 truncate">{{ getControllerName(controllerId) }}</span>
-              <button
-                type="button"
-                class="btn btn-ghost btn-xs btn-square"
-                :class="fetchControllerId === controllerId && fetchSuccess ? 'text-success' : 'text-primary'"
-                :disabled="isFetchingDetails"
-                @click="fetchMinerDetails(controllerId)"
-                title="Fetch Miner Details"
-              >
-                <PhCheck v-if="fetchControllerId === controllerId && fetchSuccess" :size="14" />
-                <PhDownloadSimple v-else :size="14" :class="{ 'animate-bounce': isFetchingDetails && fetchControllerId === controllerId }" />
-              </button>
               <button
                 type="button"
                 class="btn btn-ghost btn-xs btn-square text-error"
@@ -354,6 +395,31 @@ function handleSave() {
                   {{ unit }}
                 </option>
               </select>
+              <!-- Fetch Hash Rate: single controller -->
+              <button
+                v-if="hashRateControllers.length === 1"
+                type="button"
+                class="btn btn-sm btn-square"
+                :class="fieldFetchSuccess['hash_rate_max'] ? 'btn-success' : 'btn-ghost'"
+                :disabled="fieldFetching['hash_rate_max']"
+                @click="fetchField('hash_rate_max', hashRateControllers[0])"
+                :title="`Fetch from ${getControllerName(hashRateControllers[0])}`"
+              >
+                <PhCheck v-if="fieldFetchSuccess['hash_rate_max']" :size="16" />
+                <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['hash_rate_max'] }" />
+              </button>
+              <!-- Fetch Hash Rate: multiple controllers -->
+              <div v-else-if="hashRateControllers.length > 1" class="dropdown dropdown-end">
+                <label tabindex="0" class="btn btn-sm btn-square" :class="fieldFetchSuccess['hash_rate_max'] ? 'btn-success' : 'btn-ghost'">
+                  <PhCheck v-if="fieldFetchSuccess['hash_rate_max']" :size="16" />
+                  <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['hash_rate_max'] }" />
+                </label>
+                <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
+                  <li v-for="cid in hashRateControllers" :key="cid">
+                    <a @click="fetchField('hash_rate_max', cid)">{{ getControllerName(cid) }}</a>
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
 
@@ -365,18 +431,45 @@ function handleSave() {
                 Max Power Consumption *
               </span>
             </label>
-            <label class="input input-bordered flex items-center gap-2 transition-colors duration-500"
-              :class="{ 'input-success border-success': highlightedFields.has('power_consumption_max') }">
-              <input
-                v-model.number="formData.power_consumption_max"
-                type="number"
-                min="0"
-                class="grow"
-                placeholder="3000"
-                required
-              />
-              <span class="text-sm text-base-content/50">W</span>
-            </label>
+            <div class="flex gap-2">
+              <label class="input input-bordered flex items-center gap-2 flex-1 transition-colors duration-500"
+                :class="{ 'input-success border-success': highlightedFields.has('power_consumption_max') }">
+                <input
+                  v-model.number="formData.power_consumption_max"
+                  type="number"
+                  min="0"
+                  class="grow"
+                  placeholder="3000"
+                  required
+                />
+                <span class="text-sm text-base-content/50">W</span>
+              </label>
+              <!-- Fetch Power: single controller -->
+              <button
+                v-if="powerControllers.length === 1"
+                type="button"
+                class="btn btn-sm btn-square"
+                :class="fieldFetchSuccess['power_consumption_max'] ? 'btn-success' : 'btn-ghost'"
+                :disabled="fieldFetching['power_consumption_max']"
+                @click="fetchField('power_consumption_max', powerControllers[0])"
+                :title="`Fetch from ${getControllerName(powerControllers[0])}`"
+              >
+                <PhCheck v-if="fieldFetchSuccess['power_consumption_max']" :size="16" />
+                <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['power_consumption_max'] }" />
+              </button>
+              <!-- Fetch Power: multiple controllers -->
+              <div v-else-if="powerControllers.length > 1" class="dropdown dropdown-end">
+                <label tabindex="0" class="btn btn-sm btn-square" :class="fieldFetchSuccess['power_consumption_max'] ? 'btn-success' : 'btn-ghost'">
+                  <PhCheck v-if="fieldFetchSuccess['power_consumption_max']" :size="16" />
+                  <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['power_consumption_max'] }" />
+                </label>
+                <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
+                  <li v-for="cid in powerControllers" :key="cid">
+                    <a @click="fetchField('power_consumption_max', cid)">{{ getControllerName(cid) }}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
         </div>
 

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch, toRaw } from "vue";
-import { MinerFeatureType, type Miner, type MinerStateSnapshot } from "../../core/models/miner";
+import { MinerFeatureType, type Miner, type MinerLimit } from "../../core/models/miner";
 import { useMinerControllerStore } from "../../core/stores/minerControllerStore";
-import { MinerControllerService } from "../../core/services/minerControllerService";
+import { MinerService } from "../../core/services/minerService";
 import {
   PhX,
   PhFloppyDisk,
@@ -37,7 +37,7 @@ const emit = defineEmits<{
 }>();
 
 const minerControllerStore = useMinerControllerStore();
-const minerControllerService = new MinerControllerService();
+const minerService = new MinerService();
 
 // Hash rate unit options
 const hashRateUnits = ["H/s", "KH/s", "MH/s", "GH/s", "TH/s", "PH/s", "EH/s"];
@@ -180,25 +180,6 @@ const highlightedFields = ref<Set<string>>(new Set());
 const fieldFetching = ref<Record<string, boolean>>({});
 const fieldFetchSuccess = ref<Record<string, boolean>>({});
 
-// Resolve which selected controllers provide a given feature type (from localFeatures)
-function controllersForFeature(featureType: MinerFeatureType): string[] {
-  const seen = new Set<string>();
-  return localFeatures.value
-    .filter(
-      (f) =>
-        f.feature_type === featureType &&
-        f.enabled &&
-        selectedControllerIds.value.includes(f.controller_id)
-    )
-    .sort((a, b) => b.priority - a.priority)
-    .map((f) => f.controller_id)
-    .filter((id) => {
-      if (seen.has(id)) return false;
-      seen.add(id);
-      return true;
-    });
-}
-
 // --- Feature management ---
 
 // Group features by type (only for selected controllers)
@@ -295,25 +276,26 @@ const hasFeatureChanges = computed(() => {
   });
 });
 
-const modelControllers = computed(() => controllersForFeature(MinerFeatureType.MODEL_DETECTION));
-const hashRateControllers = computed(() => controllersForFeature(MinerFeatureType.HASHRATE_MONITORING));
-const powerControllers = computed(() => controllersForFeature(MinerFeatureType.POWER_MONITORING));
 
-async function fetchField(field: string, controllerId: string) {
+async function fetchLimit(field: "hash_rate_max" | "power_consumption_max") {
+  if (!formData.value.id) {
+    fetchError.value = "Miner must be saved before fetching limits";
+    return;
+  }
   fieldFetching.value = { ...fieldFetching.value, [field]: true };
   fieldFetchSuccess.value = { ...fieldFetchSuccess.value, [field]: false };
   fetchError.value = null;
   try {
-    const snapshot: MinerStateSnapshot = await minerControllerService.getMinerDetails(controllerId);
+    const limits: MinerLimit = await minerService.getMinerLimits(formData.value.id);
     let updated = false;
-    if (field === "hash_rate_max" && snapshot.hash_rate && snapshot.hash_rate.value > 0) {
+    if (field === "hash_rate_max" && limits.max_hash_rate && limits.max_hash_rate.value > 0) {
       formData.value.hash_rate_max = {
-        value: snapshot.hash_rate.value,
-        unit: snapshot.hash_rate.unit || "TH/s",
+        value: limits.max_hash_rate.value,
+        unit: limits.max_hash_rate.unit || "TH/s",
       };
       updated = true;
-    } else if (field === "power_consumption_max" && snapshot.power_consumption && snapshot.power_consumption > 0) {
-      formData.value.power_consumption_max = snapshot.power_consumption;
+    } else if (field === "power_consumption_max" && limits.max_power && limits.max_power > 0) {
+      formData.value.power_consumption_max = limits.max_power;
       updated = true;
     }
     if (updated) {
@@ -326,7 +308,7 @@ async function fetchField(field: string, controllerId: string) {
     }
   } catch (error: any) {
     fetchError.value =
-      error?.response?.data?.detail || error?.message || "Failed to fetch from controller";
+      error?.response?.data?.detail || error?.message || "Failed to fetch limits";
   } finally {
     fieldFetching.value = { ...fieldFetching.value, [field]: false };
   }
@@ -398,31 +380,6 @@ function handleSave() {
                 class="input input-bordered w-full flex-1 transition-colors duration-500"
                 :class="{ 'input-success border-success': highlightedFields.has('model') }"
               />
-              <!-- Fetch Model: single controller -->
-              <button
-                v-if="modelControllers.length === 1"
-                type="button"
-                class="btn btn-sm btn-square"
-                :class="fieldFetchSuccess['model'] ? 'btn-success' : 'btn-ghost'"
-                :disabled="fieldFetching['model']"
-                @click="fetchField('model', modelControllers[0])"
-                :title="`Fetch from ${getControllerName(modelControllers[0])}`"
-              >
-                <PhCheck v-if="fieldFetchSuccess['model']" :size="16" />
-                <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['model'] }" />
-              </button>
-              <!-- Fetch Model: multiple controllers -->
-              <div v-else-if="modelControllers.length > 1" class="dropdown dropdown-end">
-                <label tabindex="0" class="btn btn-sm btn-square" :class="fieldFetchSuccess['model'] ? 'btn-success' : 'btn-ghost'">
-                  <PhCheck v-if="fieldFetchSuccess['model']" :size="16" />
-                  <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['model'] }" />
-                </label>
-                <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
-                  <li v-for="cid in modelControllers" :key="cid">
-                    <a @click="fetchField('model', cid)">{{ getControllerName(cid) }} <span v-if="getControllerAdapterType(cid)" class="badge badge-xs" :class="getAdapterBadgeClass(cid)">{{ formatType(getControllerAdapterType(cid)!) }}</span></a>
-                  </li>
-                </ul>
-              </div>
             </div>
           </div>
         </div>
@@ -660,31 +617,19 @@ function handleSave() {
                   {{ unit }}
                 </option>
               </select>
-              <!-- Fetch Hash Rate: single controller -->
+              <!-- Fetch limits from miner -->
               <button
-                v-if="hashRateControllers.length === 1"
+                v-if="isEdit && formData.id"
                 type="button"
                 class="btn btn-sm btn-square"
                 :class="fieldFetchSuccess['hash_rate_max'] ? 'btn-success' : 'btn-ghost'"
                 :disabled="fieldFetching['hash_rate_max']"
-                @click="fetchField('hash_rate_max', hashRateControllers[0])"
-                :title="`Fetch from ${getControllerName(hashRateControllers[0])}`"
+                @click="fetchLimit('hash_rate_max')"
+                title="Fetch max hash rate from miner"
               >
                 <PhCheck v-if="fieldFetchSuccess['hash_rate_max']" :size="16" />
                 <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['hash_rate_max'] }" />
               </button>
-              <!-- Fetch Hash Rate: multiple controllers -->
-              <div v-else-if="hashRateControllers.length > 1" class="dropdown dropdown-end">
-                <label tabindex="0" class="btn btn-sm btn-square" :class="fieldFetchSuccess['hash_rate_max'] ? 'btn-success' : 'btn-ghost'">
-                  <PhCheck v-if="fieldFetchSuccess['hash_rate_max']" :size="16" />
-                  <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['hash_rate_max'] }" />
-                </label>
-                <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
-                  <li v-for="cid in hashRateControllers" :key="cid">
-                    <a @click="fetchField('hash_rate_max', cid)">{{ getControllerName(cid) }} <span v-if="getControllerAdapterType(cid)" class="badge badge-xs" :class="getAdapterBadgeClass(cid)">{{ formatType(getControllerAdapterType(cid)!) }}</span></a>
-                  </li>
-                </ul>
-              </div>
             </div>
           </div>
 
@@ -709,31 +654,19 @@ function handleSave() {
                 />
                 <span class="text-sm text-base-content/50">W</span>
               </label>
-              <!-- Fetch Power: single controller -->
+              <!-- Fetch max power from miner -->
               <button
-                v-if="powerControllers.length === 1"
+                v-if="isEdit && formData.id"
                 type="button"
                 class="btn btn-sm btn-square"
                 :class="fieldFetchSuccess['power_consumption_max'] ? 'btn-success' : 'btn-ghost'"
                 :disabled="fieldFetching['power_consumption_max']"
-                @click="fetchField('power_consumption_max', powerControllers[0])"
-                :title="`Fetch from ${getControllerName(powerControllers[0])}`"
+                @click="fetchLimit('power_consumption_max')"
+                title="Fetch max power from miner"
               >
                 <PhCheck v-if="fieldFetchSuccess['power_consumption_max']" :size="16" />
                 <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['power_consumption_max'] }" />
               </button>
-              <!-- Fetch Power: multiple controllers -->
-              <div v-else-if="powerControllers.length > 1" class="dropdown dropdown-end">
-                <label tabindex="0" class="btn btn-sm btn-square" :class="fieldFetchSuccess['power_consumption_max'] ? 'btn-success' : 'btn-ghost'">
-                  <PhCheck v-if="fieldFetchSuccess['power_consumption_max']" :size="16" />
-                  <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['power_consumption_max'] }" />
-                </label>
-                <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
-                  <li v-for="cid in powerControllers" :key="cid">
-                    <a @click="fetchField('power_consumption_max', cid)">{{ getControllerName(cid) }} <span v-if="getControllerAdapterType(cid)" class="badge badge-xs" :class="getAdapterBadgeClass(cid)">{{ formatType(getControllerAdapterType(cid)!) }}</span></a>
-                  </li>
-                </ul>
-              </div>
             </div>
           </div>
         </div>

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -57,6 +57,7 @@ const originalControllerIds = ref<string[]>([]);
 // Feature state (working copy for editing)
 const localFeatures = ref<MinerFeature[]>([]);
 const originalFeatures = ref<MinerFeature[]>([]);
+const showFeatures = ref(false);
 
 // Watch for changes in the prop to reset form
 watch(
@@ -74,6 +75,7 @@ watch(
         originalControllerIds.value = [...(props.miner.controller_ids ?? [])];
         localFeatures.value = (props.miner.features ?? []).map((f) => ({ ...f }));
         originalFeatures.value = (props.miner.features ?? []).map((f) => ({ ...f }));
+        showFeatures.value = false;
       } else {
         formData.value = {
           name: "",
@@ -85,6 +87,7 @@ watch(
         originalControllerIds.value = [];
         localFeatures.value = [];
         originalFeatures.value = [];
+        showFeatures.value = false;
       }
     }
   },
@@ -262,6 +265,22 @@ function updateFeaturePriority(featureType: MinerFeatureType, controllerId: stri
       priority: Math.max(1, Math.min(100, priority)),
     };
   }
+}
+
+// Swap priority between two controllers for a given feature type
+// direction: 'up' = swap with higher-priority neighbor, 'down' = swap with lower-priority neighbor
+function swapFeaturePriority(featureType: MinerFeatureType, controllerId: string, direction: 'up' | 'down') {
+  const group = featuresByType.value.get(featureType);
+  if (!group || group.length < 2) return;
+  const currentIdx = group.findIndex((f) => f.controller_id === controllerId);
+  if (currentIdx === -1) return;
+  // group is sorted descending by priority: index 0 = highest
+  const neighborIdx = direction === 'up' ? currentIdx - 1 : currentIdx + 1;
+  if (neighborIdx < 0 || neighborIdx >= group.length) return;
+  const currentPriority = group[currentIdx].priority;
+  const neighborPriority = group[neighborIdx].priority;
+  updateFeaturePriority(featureType, controllerId, neighborPriority);
+  updateFeaturePriority(featureType, group[neighborIdx].controller_id, currentPriority);
 }
 
 // Check if features have been modified
@@ -480,12 +499,20 @@ function handleSave() {
 
         <!-- Controller Features Section -->
         <template v-if="localFeatures.length > 0 && selectedControllerIds.length > 0">
-          <div class="divider text-xs text-base-content/50 my-4">
-            <PhArrowsDownUp :size="14" />
-            CONTROLLER FEATURES
+          <!-- Manage Features toggle button -->
+          <div class="flex items-center justify-center my-2">
+            <button
+              type="button"
+              class="btn btn-xs btn-ghost gap-1.5 text-base-content/50 hover:text-base-content"
+              @click="showFeatures = !showFeatures"
+            >
+              <PhArrowsDownUp :size="14" />
+              {{ showFeatures ? 'Hide Features' : 'Manage Features' }}
+              <span v-if="hasFeatureChanges" class="badge badge-xs badge-warning">modified</span>
+            </button>
           </div>
 
-          <div class="space-y-2">
+          <div v-if="showFeatures" class="space-y-2">
             <div
               v-for="[featureType, features] in featuresByType"
               :key="featureType"
@@ -543,9 +570,10 @@ function handleSave() {
                     <button
                       type="button"
                       class="btn btn-ghost btn-xs btn-square min-h-0 h-5 w-5"
-                      :disabled="!feature.enabled || feature.priority >= 100"
-                      @click="updateFeaturePriority(feature.feature_type, feature.controller_id, feature.priority + 10)"
-                      title="Priority +10"
+                      :class="{ 'invisible': !(features.length > 1 && features[features.length - 1].controller_id === feature.controller_id) }"
+                      :disabled="!feature.enabled"
+                      @click="swapFeaturePriority(feature.feature_type, feature.controller_id, 'up')"
+                      title="Increase priority"
                     >
                       <PhCaretUp :size="12" />
                     </button>
@@ -561,9 +589,10 @@ function handleSave() {
                     <button
                       type="button"
                       class="btn btn-ghost btn-xs btn-square min-h-0 h-5 w-5"
-                      :disabled="!feature.enabled || feature.priority <= 1"
-                      @click="updateFeaturePriority(feature.feature_type, feature.controller_id, feature.priority - 10)"
-                      title="Priority -10"
+                      :class="{ 'invisible': !(features.length > 1 && features[0].controller_id === feature.controller_id) }"
+                      :disabled="!feature.enabled"
+                      @click="swapFeaturePriority(feature.feature_type, feature.controller_id, 'down')"
+                      title="Decrease priority"
                     >
                       <PhCaretDown :size="12" />
                     </button>

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -13,7 +13,15 @@ import {
   PhCheck,
   PhPlus,
   PhTrash,
+  PhEye,
+  PhToggleRight,
+  PhMagnifyingGlass,
+  PhWarningCircle,
+  PhArrowsDownUp,
+  PhCaretUp,
+  PhCaretDown,
 } from "@phosphor-icons/vue";
+import type { MinerFeature } from "../../core/models/miner";
 import { formatType } from "../../core/utils/formatters";
 
 const props = defineProps<{
@@ -25,7 +33,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   close: [];
-  save: [miner: Miner, controllerChanges: { add: string[]; remove: string[] }];
+  save: [miner: Miner, controllerChanges: { add: string[]; remove: string[] }, featureUpdates: MinerFeature[]];
 }>();
 
 const minerControllerStore = useMinerControllerStore();
@@ -46,6 +54,10 @@ const formData = ref<Miner>({
 const selectedControllerIds = ref<string[]>([]);
 const originalControllerIds = ref<string[]>([]);
 
+// Feature state (working copy for editing)
+const localFeatures = ref<MinerFeature[]>([]);
+const originalFeatures = ref<MinerFeature[]>([]);
+
 // Watch for changes in the prop to reset form
 watch(
   () => props.open,
@@ -60,6 +72,8 @@ watch(
         };
         selectedControllerIds.value = [...(props.miner.controller_ids ?? [])];
         originalControllerIds.value = [...(props.miner.controller_ids ?? [])];
+        localFeatures.value = (props.miner.features ?? []).map((f) => ({ ...f }));
+        originalFeatures.value = (props.miner.features ?? []).map((f) => ({ ...f }));
       } else {
         formData.value = {
           name: "",
@@ -69,6 +83,8 @@ watch(
         };
         selectedControllerIds.value = [];
         originalControllerIds.value = [];
+        localFeatures.value = [];
+        originalFeatures.value = [];
       }
     }
   },
@@ -161,11 +177,10 @@ const highlightedFields = ref<Set<string>>(new Set());
 const fieldFetching = ref<Record<string, boolean>>({});
 const fieldFetchSuccess = ref<Record<string, boolean>>({});
 
-// Resolve which selected controllers provide a given feature type (from miner.features)
+// Resolve which selected controllers provide a given feature type (from localFeatures)
 function controllersForFeature(featureType: MinerFeatureType): string[] {
-  if (!props.miner?.features) return [];
   const seen = new Set<string>();
-  return props.miner.features
+  return localFeatures.value
     .filter(
       (f) =>
         f.feature_type === featureType &&
@@ -180,6 +195,86 @@ function controllersForFeature(featureType: MinerFeatureType): string[] {
       return true;
     });
 }
+
+// --- Feature management ---
+
+// Group features by type (only for selected controllers)
+const featuresByType = computed(() => {
+  const groups = new Map<MinerFeatureType, MinerFeature[]>();
+  for (const feature of localFeatures.value) {
+    if (!selectedControllerIds.value.includes(feature.controller_id)) continue;
+    const existing = groups.get(feature.feature_type) || [];
+    existing.push(feature);
+    groups.set(feature.feature_type, existing);
+  }
+  // Sort each group by priority descending
+  for (const [key, features] of groups) {
+    groups.set(key, features.sort((a, b) => b.priority - a.priority));
+  }
+  return groups;
+});
+
+// Feature category icon
+function getFeatureCategoryIcon(featureType: string) {
+  if (featureType.endsWith('_control')) return PhToggleRight;
+  if (featureType === 'model_detection') return PhMagnifyingGlass;
+  return PhEye;
+}
+
+// Determine role of a feature within its group
+function getFeatureRole(feature: MinerFeature): 'active' | 'fallback' | 'disabled' {
+  if (!feature.enabled) return 'disabled';
+  const group = featuresByType.value.get(feature.feature_type) || [];
+  const enabledFeatures = group.filter((f) => f.enabled);
+  if (enabledFeatures.length === 0) return 'disabled';
+  // The one with highest priority is active
+  if (enabledFeatures[0].controller_id === feature.controller_id) return 'active';
+  return 'fallback';
+}
+
+// Check if a feature type has multiple enabled providers
+function hasMultipleProviders(featureType: MinerFeatureType): boolean {
+  const group = featuresByType.value.get(featureType) || [];
+  return group.filter((f) => f.enabled).length > 1;
+}
+
+// Toggle feature enabled state
+function toggleFeatureEnabled(featureType: MinerFeatureType, controllerId: string) {
+  const idx = localFeatures.value.findIndex(
+    (f) => f.feature_type === featureType && f.controller_id === controllerId
+  );
+  if (idx !== -1) {
+    localFeatures.value[idx] = {
+      ...localFeatures.value[idx],
+      enabled: !localFeatures.value[idx].enabled,
+    };
+  }
+}
+
+// Update feature priority
+function updateFeaturePriority(featureType: MinerFeatureType, controllerId: string, priority: number) {
+  const idx = localFeatures.value.findIndex(
+    (f) => f.feature_type === featureType && f.controller_id === controllerId
+  );
+  if (idx !== -1) {
+    localFeatures.value[idx] = {
+      ...localFeatures.value[idx],
+      priority: Math.max(1, Math.min(100, priority)),
+    };
+  }
+}
+
+// Check if features have been modified
+const hasFeatureChanges = computed(() => {
+  if (localFeatures.value.length !== originalFeatures.value.length) return true;
+  return localFeatures.value.some((f) => {
+    const orig = originalFeatures.value.find(
+      (o) => o.feature_type === f.feature_type && o.controller_id === f.controller_id
+    );
+    if (!orig) return true;
+    return f.enabled !== orig.enabled || f.priority !== orig.priority;
+  });
+});
 
 const modelControllers = computed(() => controllersForFeature(MinerFeatureType.MODEL_DETECTION));
 const hashRateControllers = computed(() => controllersForFeature(MinerFeatureType.HASHRATE_MONITORING));
@@ -225,7 +320,9 @@ function handleSave() {
     // Remove controller-related fields from miner payload (backend no longer accepts them)
     delete rawData.features;
     delete rawData.controller_ids;
-    emit("save", rawData, { ...controllerChanges.value });
+    // Clone features for emission
+    const rawFeatures: MinerFeature[] = JSON.parse(JSON.stringify(toRaw(localFeatures.value)));
+    emit("save", rawData, { ...controllerChanges.value }, rawFeatures);
   }
 }
 </script>
@@ -380,6 +477,127 @@ function handleSave() {
             <span>{{ fetchError }}</span>
           </div>
         </div>
+
+        <!-- Controller Features Section -->
+        <template v-if="localFeatures.length > 0 && selectedControllerIds.length > 0">
+          <div class="divider text-xs text-base-content/50 my-4">
+            <PhArrowsDownUp :size="14" />
+            CONTROLLER FEATURES
+          </div>
+
+          <div class="space-y-2">
+            <div
+              v-for="[featureType, features] in featuresByType"
+              :key="featureType"
+              class="bg-base-200/30 rounded-lg px-3 py-2.5"
+            >
+              <!-- Feature Type Header -->
+              <div class="flex items-center gap-2 mb-1.5">
+                <component :is="getFeatureCategoryIcon(featureType)" :size="14" class="text-info flex-shrink-0" />
+                <span class="text-sm font-medium text-base-content">{{ formatType(featureType) }}</span>
+                <span
+                  v-if="hasMultipleProviders(featureType)"
+                  class="badge badge-xs badge-warning gap-1"
+                  title="Multiple controllers provide this feature"
+                >
+                  <PhWarningCircle :size="10" />
+                  {{ features.filter((f) => f.enabled).length }} providers
+                </span>
+              </div>
+
+              <!-- Controllers providing this feature -->
+              <div class="space-y-1">
+                <div
+                  v-for="feature in features"
+                  :key="feature.controller_id"
+                  class="flex items-center gap-2 py-1 pl-5"
+                  :class="{ 'opacity-40': !feature.enabled }"
+                >
+                  <!-- Role indicator dot -->
+                  <span
+                    class="w-2 h-2 rounded-full flex-shrink-0"
+                    :class="{
+                      'bg-success': getFeatureRole(feature) === 'active',
+                      'bg-warning': getFeatureRole(feature) === 'fallback',
+                      'bg-base-content/20': getFeatureRole(feature) === 'disabled',
+                    }"
+                  />
+
+                  <!-- Controller name -->
+                  <span class="text-xs flex-1 truncate">
+                    {{ getControllerName(feature.controller_id) }}
+                  </span>
+
+                  <!-- Adapter type badge -->
+                  <span
+                    v-if="getControllerAdapterType(feature.controller_id)"
+                    class="badge badge-xs"
+                    :class="getAdapterBadgeClass(feature.controller_id)"
+                  >
+                    {{ formatType(getControllerAdapterType(feature.controller_id)!) }}
+                  </span>
+
+                  <!-- Priority input -->
+                  <div class="flex items-center gap-0.5 ml-1">
+                    <span class="text-[10px] text-base-content/40 uppercase">Pri</span>
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square min-h-0 h-5 w-5"
+                      :disabled="!feature.enabled || feature.priority >= 100"
+                      @click="updateFeaturePriority(feature.feature_type, feature.controller_id, feature.priority + 10)"
+                      title="Priority +10"
+                    >
+                      <PhCaretUp :size="12" />
+                    </button>
+                    <input
+                      type="number"
+                      :value="feature.priority"
+                      @change="updateFeaturePriority(feature.feature_type, feature.controller_id, parseInt(($event.target as HTMLInputElement).value) || 50)"
+                      min="1"
+                      max="100"
+                      class="input input-xs input-bordered w-14 text-center"
+                      :disabled="!feature.enabled"
+                    />
+                    <button
+                      type="button"
+                      class="btn btn-ghost btn-xs btn-square min-h-0 h-5 w-5"
+                      :disabled="!feature.enabled || feature.priority <= 1"
+                      @click="updateFeaturePriority(feature.feature_type, feature.controller_id, feature.priority - 10)"
+                      title="Priority -10"
+                    >
+                      <PhCaretDown :size="12" />
+                    </button>
+                  </div>
+
+                  <!-- Enable/disable toggle -->
+                  <input
+                    type="checkbox"
+                    class="toggle toggle-xs toggle-primary"
+                    :checked="feature.enabled"
+                    @change="toggleFeatureEnabled(feature.feature_type, feature.controller_id)"
+                  />
+
+                  <!-- Role badge -->
+                  <span
+                    class="badge badge-xs w-16 justify-center"
+                    :class="{
+                      'badge-success': getFeatureRole(feature) === 'active',
+                      'badge-warning': getFeatureRole(feature) === 'fallback',
+                      'badge-ghost text-base-content/30': getFeatureRole(feature) === 'disabled',
+                    }"
+                  >
+                    {{ getFeatureRole(feature) === 'active' ? 'Active' : getFeatureRole(feature) === 'fallback' ? 'Fallback' : 'Off' }}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Note for newly added controllers -->
+          <p v-if="controllerChanges.add.length > 0" class="text-xs text-base-content/40 mt-2 italic">
+            Features for newly added controllers will appear after saving.
+          </p>
+        </template>
 
         <!-- Performance Settings -->
         <div class="divider text-xs text-base-content/50 my-4">

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -14,6 +14,7 @@ import {
   PhPlus,
   PhTrash,
 } from "@phosphor-icons/vue";
+import { formatType } from "../../core/utils/formatters";
 
 const props = defineProps<{
   open: boolean;
@@ -110,6 +111,22 @@ function removeController(controllerId: string) {
 function getControllerName(controllerId: string): string {
   const controller = minerControllerStore.minerControllers.find((mc) => mc.id === controllerId);
   return controller?.name ?? controllerId;
+}
+
+function getControllerAdapterType(controllerId: string): string | undefined {
+  const controller = minerControllerStore.minerControllers.find((mc) => mc.id === controllerId);
+  return controller?.adapter_type;
+}
+
+const adapterBadgeClass: Record<string, string> = {
+  dummy: "bg-slate-500/20 text-slate-400",
+  pyasic: "bg-emerald-500/20 text-emerald-400",
+  generic_socket_home_assistant_api: "bg-sky-500/20 text-sky-400",
+};
+
+function getAdapterBadgeClass(controllerId: string): string {
+  const adapterType = getControllerAdapterType(controllerId);
+  return adapterType ? (adapterBadgeClass[adapterType] ?? "badge-ghost") : "badge-ghost";
 }
 
 // Compute controller changes (diff)
@@ -286,7 +303,7 @@ function handleSave() {
                 </label>
                 <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
                   <li v-for="cid in modelControllers" :key="cid">
-                    <a @click="fetchField('model', cid)">{{ getControllerName(cid) }}</a>
+                    <a @click="fetchField('model', cid)">{{ getControllerName(cid) }} <span v-if="getControllerAdapterType(cid)" class="badge badge-xs" :class="getAdapterBadgeClass(cid)">{{ formatType(getControllerAdapterType(cid)!) }}</span></a>
                   </li>
                 </ul>
               </div>
@@ -316,6 +333,7 @@ function handleSave() {
             >
               <PhGear :size="14" class="text-info flex-shrink-0" />
               <span class="text-sm text-base-content flex-1 truncate">{{ getControllerName(controllerId) }}</span>
+              <span v-if="getControllerAdapterType(controllerId)" class="badge badge-xs" :class="getAdapterBadgeClass(controllerId)">{{ formatType(getControllerAdapterType(controllerId)!) }}</span>
               <button
                 type="button"
                 class="btn btn-ghost btn-xs btn-square text-error"
@@ -339,7 +357,7 @@ function handleSave() {
                 :key="controller.id"
                 :value="controller.id"
               >
-                {{ controller.name }}
+                {{ controller.name }} ({{ formatType(controller.adapter_type) }})
               </option>
             </select>
             <button
@@ -416,7 +434,7 @@ function handleSave() {
                 </label>
                 <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
                   <li v-for="cid in hashRateControllers" :key="cid">
-                    <a @click="fetchField('hash_rate_max', cid)">{{ getControllerName(cid) }}</a>
+                    <a @click="fetchField('hash_rate_max', cid)">{{ getControllerName(cid) }} <span v-if="getControllerAdapterType(cid)" class="badge badge-xs" :class="getAdapterBadgeClass(cid)">{{ formatType(getControllerAdapterType(cid)!) }}</span></a>
                   </li>
                 </ul>
               </div>
@@ -465,7 +483,7 @@ function handleSave() {
                 </label>
                 <ul tabindex="0" class="dropdown-content z-[1] menu p-1 shadow-lg bg-base-200 rounded-box w-52">
                   <li v-for="cid in powerControllers" :key="cid">
-                    <a @click="fetchField('power_consumption_max', cid)">{{ getControllerName(cid) }}</a>
+                    <a @click="fetchField('power_consumption_max', cid)">{{ getControllerName(cid) }} <span v-if="getControllerAdapterType(cid)" class="badge badge-xs" :class="getAdapterBadgeClass(cid)">{{ formatType(getControllerAdapterType(cid)!) }}</span></a>
                   </li>
                 </ul>
               </div>

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch, toRaw } from "vue";
-import { MinerFeatureType, type Miner, type MinerLimit } from "../../core/models/miner";
+import { MinerFeatureType, type Miner, type MinerInfo, type MinerLimit } from "../../core/models/miner";
 import { useMinerControllerStore } from "../../core/stores/minerControllerStore";
 import { MinerService } from "../../core/services/minerService";
 import {
@@ -59,6 +59,9 @@ const localFeatures = ref<MinerFeature[]>([]);
 const originalFeatures = ref<MinerFeature[]>([]);
 const showFeatures = ref(false);
 
+// Device info state (fetched from /miners/{id}/info)
+const deviceInfo = ref<MinerInfo | null>(null);
+
 // Watch for changes in the prop to reset form
 watch(
   () => props.open,
@@ -76,6 +79,7 @@ watch(
         localFeatures.value = (props.miner.features ?? []).map((f) => ({ ...f }));
         originalFeatures.value = (props.miner.features ?? []).map((f) => ({ ...f }));
         showFeatures.value = false;
+        deviceInfo.value = null;
       } else {
         formData.value = {
           name: "",
@@ -88,6 +92,7 @@ watch(
         localFeatures.value = [];
         originalFeatures.value = [];
         showFeatures.value = false;
+        deviceInfo.value = null;
       }
     }
   },
@@ -277,6 +282,58 @@ const hasFeatureChanges = computed(() => {
 });
 
 
+// Check if miner has the DEVICE_INFO_DETECTION feature enabled
+const hasDeviceInfoFeature = computed(() => {
+  return localFeatures.value.some(
+    (f) =>
+      f.feature_type === MinerFeatureType.DEVICE_INFO_DETECTION &&
+      f.enabled &&
+      selectedControllerIds.value.includes(f.controller_id)
+  );
+});
+
+async function ensureDeviceInfo(): Promise<MinerInfo | null> {
+  if (deviceInfo.value) return deviceInfo.value;
+  if (!formData.value.id) {
+    fetchError.value = "Miner must be saved before fetching info";
+    return null;
+  }
+  const info = await minerService.getMinerInfo(formData.value.id);
+  if (info) deviceInfo.value = info;
+  return info;
+}
+
+async function fetchInfoField(field: "name" | "model") {
+  fieldFetching.value = { ...fieldFetching.value, [field]: true };
+  fieldFetchSuccess.value = { ...fieldFetchSuccess.value, [field]: false };
+  fetchError.value = null;
+  try {
+    const info = await ensureDeviceInfo();
+    if (!info) return;
+    let updated = false;
+    if (field === "name" && info.hostname) {
+      formData.value.name = info.hostname;
+      updated = true;
+    } else if (field === "model" && info.model) {
+      formData.value.model = info.model;
+      updated = true;
+    }
+    if (updated) {
+      highlightedFields.value = new Set([field]);
+      fieldFetchSuccess.value = { ...fieldFetchSuccess.value, [field]: true };
+      setTimeout(() => {
+        fieldFetchSuccess.value = { ...fieldFetchSuccess.value, [field]: false };
+        highlightedFields.value = new Set();
+      }, 3000);
+    }
+  } catch (error: any) {
+    fetchError.value =
+      error?.response?.data?.detail || error?.message || "Failed to fetch miner info";
+  } finally {
+    fieldFetching.value = { ...fieldFetching.value, [field]: false };
+  }
+}
+
 async function fetchLimit(field: "hash_rate_max" | "power_consumption_max") {
   if (!formData.value.id) {
     fetchError.value = "Miner must be saved before fetching limits";
@@ -358,13 +415,29 @@ function handleSave() {
             <label class="label mb-1">
               <span class="label-text font-medium">Name *</span>
             </label>
-            <input
-              v-model="formData.name"
-              type="text"
-              placeholder="Enter miner name"
-              class="input input-bordered w-full"
-              required
-            />
+            <div class="flex gap-2">
+              <input
+                v-model="formData.name"
+                type="text"
+                placeholder="Enter miner name"
+                class="input input-bordered w-full flex-1 transition-colors duration-500"
+                :class="{ 'input-success border-success': highlightedFields.has('name') }"
+                required
+              />
+              <!-- Fetch hostname from device info -->
+              <button
+                v-if="isEdit && formData.id && hasDeviceInfoFeature"
+                type="button"
+                class="btn btn-sm btn-square"
+                :class="fieldFetchSuccess['name'] ? 'btn-success' : 'btn-ghost'"
+                :disabled="fieldFetching['name']"
+                @click="fetchInfoField('name')"
+                title="Fetch hostname from miner"
+              >
+                <PhCheck v-if="fieldFetchSuccess['name']" :size="16" />
+                <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['name'] }" />
+              </button>
+            </div>
           </div>
 
           <!-- Model Input -->
@@ -380,6 +453,19 @@ function handleSave() {
                 class="input input-bordered w-full flex-1 transition-colors duration-500"
                 :class="{ 'input-success border-success': highlightedFields.has('model') }"
               />
+              <!-- Fetch model from device info -->
+              <button
+                v-if="isEdit && formData.id && hasDeviceInfoFeature"
+                type="button"
+                class="btn btn-sm btn-square"
+                :class="fieldFetchSuccess['model'] ? 'btn-success' : 'btn-ghost'"
+                :disabled="fieldFetching['model']"
+                @click="fetchInfoField('model')"
+                title="Fetch model from miner"
+              >
+                <PhCheck v-if="fieldFetchSuccess['model']" :size="16" />
+                <PhDownloadSimple v-else :size="16" :class="{ 'animate-bounce': fieldFetching['model'] }" />
+              </button>
             </div>
           </div>
         </div>
@@ -672,16 +758,33 @@ function handleSave() {
         </div>
 
         <!-- Actions -->
-        <div class="flex justify-end gap-3 pt-4 border-t border-base-300/40">
-          <button type="button" class="btn btn-ghost" @click="handleClose">Cancel</button>
-          <button
-            type="submit"
-            class="btn btn-primary"
-            :disabled="!isFormValid"
-          >
-            <PhFloppyDisk :size="18" />
-            {{ isEdit ? "Save Changes" : "Create" }}
-          </button>
+        <div class="flex items-end gap-3 pt-4 border-t border-base-300/40">
+          <!-- Device info (footer left) -->
+          <div v-if="deviceInfo" class="flex-1 text-xs text-base-content/40 space-y-0.5">
+            <div v-if="deviceInfo.firmware_version">
+              <span class="text-base-content/50">Firmware:</span> {{ deviceInfo.firmware_version }}
+            </div>
+            <div v-if="deviceInfo.mac_address">
+              <span class="text-base-content/50">MAC:</span> {{ deviceInfo.mac_address }}
+            </div>
+            <div v-if="deviceInfo.serial_number">
+              <span class="text-base-content/50">S/N:</span> {{ deviceInfo.serial_number }}
+            </div>
+          </div>
+          <div v-else class="flex-1"></div>
+
+          <!-- Buttons (footer right) -->
+          <div class="flex gap-3">
+            <button type="button" class="btn btn-ghost" @click="handleClose">Cancel</button>
+            <button
+              type="submit"
+              class="btn btn-primary"
+              :disabled="!isFormValid"
+            >
+              <PhFloppyDisk :size="18" />
+              {{ isEdit ? "Save Changes" : "Create" }}
+            </button>
+          </div>
         </div>
       </form>
     </div>

--- a/src/components/miners/MinerFormModal.vue
+++ b/src/components/miners/MinerFormModal.vue
@@ -760,15 +760,22 @@ function handleSave() {
         <!-- Actions -->
         <div class="flex items-end gap-3 pt-4 border-t border-base-300/40">
           <!-- Device info (footer left) -->
-          <div v-if="deviceInfo" class="flex-1 text-xs text-base-content/40 space-y-0.5">
-            <div v-if="deviceInfo.firmware_version">
-              <span class="text-base-content/50">Firmware:</span> {{ deviceInfo.firmware_version }}
+          <div v-if="deviceInfo" class="flex-1 text-xs text-base-content/40 truncate">
+            <div>
+              <template v-if="deviceInfo.firmware_type">
+                <span class="text-base-content/50">FW:</span> {{ deviceInfo.firmware_type }}<template v-if="deviceInfo.firmware_version"> {{ deviceInfo.firmware_version }}</template>
+              </template>
+              <template v-else-if="deviceInfo.firmware_version">
+                <span class="text-base-content/50">FW:</span> {{ deviceInfo.firmware_version }}
+              </template>
             </div>
-            <div v-if="deviceInfo.mac_address">
-              <span class="text-base-content/50">MAC:</span> {{ deviceInfo.mac_address }}
-            </div>
-            <div v-if="deviceInfo.serial_number">
-              <span class="text-base-content/50">S/N:</span> {{ deviceInfo.serial_number }}
+            <div>
+              <template v-if="deviceInfo.mac_address">
+                <span class="text-base-content/50">MAC:</span> {{ deviceInfo.mac_address }}
+              </template>
+              <template v-if="deviceInfo.serial_number">
+                <span v-if="deviceInfo.mac_address"> · </span><span class="text-base-content/50">S/N:</span> {{ deviceInfo.serial_number }}
+              </template>
             </div>
           </div>
           <div v-else class="flex-1"></div>

--- a/src/core/composables/useDashboardPolling.ts
+++ b/src/core/composables/useDashboardPolling.ts
@@ -31,6 +31,10 @@ export function useDashboardPolling(intervalMs = 5000) {
   const batteryPowerSeries = computed(() => dashboardStore.batteryPowerSeries);
   const gridPowerSeries = computed(() => dashboardStore.gridPowerSeries);
   const consumptionSeries = computed(() => dashboardStore.consumptionSeries);
+  const maxChipTempSeries = computed(() => dashboardStore.maxChipTempSeries);
+  const maxBoardTempSeries = computed(() => dashboardStore.maxBoardTempSeries);
+  const internalFanSpeedSeries = computed(() => dashboardStore.internalFanSpeedSeries);
+  const externalFanSpeedSeries = computed(() => dashboardStore.externalFanSpeedSeries);
   const events = computed(() => dashboardStore.events);
   const minerOnOffEvents = computed(() => dashboardStore.minerOnOffEvents);
   const latestDecisionalContexts = computed(() => dashboardStore.latestDecisionalContexts);
@@ -97,6 +101,11 @@ export function useDashboardPolling(intervalMs = 5000) {
 
     let totalHash = 0;
     let totalPower = 0;
+    let maxChipTemp: number | null = null;
+    let maxBoardTemp: number | null = null;
+    let maxInternalFanSpeed: number | null = null;
+    let latestExternalFanSpeed: number | null = null;
+
     for (const m of minerStore.miners) {
       const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
       if (state?.status === "on") {
@@ -104,11 +113,45 @@ export function useDashboardPolling(intervalMs = 5000) {
           totalHash += normalizeHashRate(state.hash_rate.value, state.hash_rate.unit || "TH/s");
         }
         totalPower += state.power_consumption || 0;
+
+        // Aggregate max chip temperature across all miners
+        if (state.max_chip_temperature?.value != null) {
+          maxChipTemp = Math.max(maxChipTemp ?? -Infinity, state.max_chip_temperature.value);
+        }
+        // Aggregate max board temperature across all miners
+        if (state.max_board_temperature?.value != null) {
+          maxBoardTemp = Math.max(maxBoardTemp ?? -Infinity, state.max_board_temperature.value);
+        }
+        // Aggregate max internal fan speed across all miners
+        if (state.internal_fan_speed?.length) {
+          for (const fs of state.internal_fan_speed) {
+            if (fs.value != null) {
+              maxInternalFanSpeed = Math.max(maxInternalFanSpeed ?? -Infinity, fs.value);
+            }
+          }
+        }
+        // Latest external fan speed (max across miners)
+        if (state.external_fan_speed?.value != null) {
+          latestExternalFanSpeed = Math.max(latestExternalFanSpeed ?? -Infinity, state.external_fan_speed.value);
+        }
       }
     }
 
     dashboardStore.addSeriesPoint("hashRate", { time: now, value: totalHash });
     dashboardStore.addSeriesPoint("power", { time: now, value: totalPower });
+
+    if (maxChipTemp !== null) {
+      dashboardStore.addSeriesPoint("maxChipTemp", { time: now, value: maxChipTemp });
+    }
+    if (maxBoardTemp !== null) {
+      dashboardStore.addSeriesPoint("maxBoardTemp", { time: now, value: maxBoardTemp });
+    }
+    if (maxInternalFanSpeed !== null) {
+      dashboardStore.addSeriesPoint("internalFanSpeed", { time: now, value: maxInternalFanSpeed });
+    }
+    if (latestExternalFanSpeed !== null) {
+      dashboardStore.addSeriesPoint("externalFanSpeed", { time: now, value: latestExternalFanSpeed });
+    }
   }
 
   async function fetchDecisionalContexts() {
@@ -264,6 +307,10 @@ export function useDashboardPolling(intervalMs = 5000) {
     batteryPowerSeries,
     gridPowerSeries,
     consumptionSeries,
+    maxChipTempSeries,
+    maxBoardTempSeries,
+    internalFanSpeedSeries,
+    externalFanSpeedSeries,
     minerOnOffEvents,
     latestDecisionalContexts,
     forecastPowerPoints,

--- a/src/core/composables/useDashboardPolling.ts
+++ b/src/core/composables/useDashboardPolling.ts
@@ -83,7 +83,7 @@ export function useDashboardPolling(intervalMs = 5000) {
 
   async function refreshMinerStatuses() {
     const pollableMiners = minerStore.miners.filter(
-      (m) => m.id != null && m.active && m.controller_id
+      (m) => m.id != null && m.active && m.controller_ids?.length
     );
     if (pollableMiners.length > 0) {
       await Promise.all(

--- a/src/core/models/miner.ts
+++ b/src/core/models/miner.ts
@@ -89,6 +89,7 @@ export interface HashboardSnapshot {
 export interface MinerInfo {
   model?: string;
   serial_number?: string;
+  firmware_type?: string;
   firmware_version?: string;
   mac_address?: string;
   hostname?: string;

--- a/src/core/models/miner.ts
+++ b/src/core/models/miner.ts
@@ -6,6 +6,35 @@ export interface HashRate {
 
 export type MinerStatus = 'unknown' | 'off' | 'on' | 'starting' | 'stopping' | 'error';
 
+// Feature types matching backend MinerFeatureType enum
+export const MinerFeatureType = {
+  HASHRATE_MONITORING: 'hashrate_monitoring',
+  POWER_MONITORING: 'power_monitoring',
+  STATUS_MONITORING: 'status_monitoring',
+  TEMPERATURE_BOARD_MONITORING: 'temperature_board_monitoring',
+  TEMPERATURE_CHIP_MONITORING: 'temperature_chip_monitoring',
+  TEMPERATURE_INTAKE_MONITORING: 'temperature_intake_monitoring',
+  TEMPERATURE_EXHAUST_MONITORING: 'temperature_exhaust_monitoring',
+  FAN_SPEED_INTERNAL_MONITORING: 'fan_speed_internal_monitoring',
+  FAN_SPEED_PSU_MONITORING: 'fan_speed_psu_monitoring',
+  VOLTAGE_MONITORING: 'voltage_monitoring',
+  FREQUENCY_MONITORING: 'frequency_monitoring',
+  MINING_CONTROL: 'mining_control',
+  POWER_CONTROL: 'power_control',
+  FREQUENCY_CONTROL: 'frequency_control',
+  FAN_SPEED_CONTROL: 'fan_speed_control',
+  MODEL_DETECTION: 'model_detection',
+} as const;
+
+export type MinerFeatureType = typeof MinerFeatureType[keyof typeof MinerFeatureType];
+
+export interface MinerFeature {
+  feature_type: MinerFeatureType;
+  controller_id: string;
+  priority: number;
+  enabled: boolean;
+}
+
 export interface Miner {
   id?: string;
   name: string;
@@ -13,7 +42,8 @@ export interface Miner {
   hash_rate_max?: HashRate;
   power_consumption_max?: number;
   active: boolean;
-  controller_id?: string;
+  features?: MinerFeature[];
+  controller_ids?: string[];
 }
 
 // Runtime operational state
@@ -21,4 +51,12 @@ export interface MinerStateSnapshot {
   status: MinerStatus;
   hash_rate?: HashRate;
   power_consumption?: number;
+  temperature_board?: number;
+  temperature_chip?: number;
+  temperature_intake?: number;
+  temperature_exhaust?: number;
+  fan_speed_internal?: number;
+  fan_speed_psu?: number;
+  voltage?: number;
+  frequency?: number;
 }

--- a/src/core/models/miner.ts
+++ b/src/core/models/miner.ts
@@ -8,22 +8,25 @@ export type MinerStatus = 'unknown' | 'off' | 'on' | 'starting' | 'stopping' | '
 
 // Feature types matching backend MinerFeatureType enum
 export const MinerFeatureType = {
+  // Monitoring (read-only)
   HASHRATE_MONITORING: 'hashrate_monitoring',
   POWER_MONITORING: 'power_monitoring',
   STATUS_MONITORING: 'status_monitoring',
-  TEMPERATURE_BOARD_MONITORING: 'temperature_board_monitoring',
-  TEMPERATURE_CHIP_MONITORING: 'temperature_chip_monitoring',
-  TEMPERATURE_INTAKE_MONITORING: 'temperature_intake_monitoring',
-  TEMPERATURE_EXHAUST_MONITORING: 'temperature_exhaust_monitoring',
+  HASHBOARD_MONITORING: 'hashboard_monitoring',
+  INLET_TEMPERATURE_MONITORING: 'inlet_temperature_monitoring',
+  OUTLET_TEMPERATURE_MONITORING: 'outlet_temperature_monitoring',
   FAN_SPEED_INTERNAL_MONITORING: 'fan_speed_internal_monitoring',
-  FAN_SPEED_PSU_MONITORING: 'fan_speed_psu_monitoring',
-  VOLTAGE_MONITORING: 'voltage_monitoring',
-  FREQUENCY_MONITORING: 'frequency_monitoring',
+  FAN_SPEED_EXTERNAL_MONITORING: 'fan_speed_external_monitoring',
+  OPERATIONAL_MONITORING: 'operational_monitoring',
+  // Control (write)
   MINING_CONTROL: 'mining_control',
   POWER_CONTROL: 'power_control',
-  FREQUENCY_CONTROL: 'frequency_control',
-  FAN_SPEED_CONTROL: 'fan_speed_control',
-  MODEL_DETECTION: 'model_detection',
+  INTERNAL_FAN_CONTROL: 'internal_fan_control',
+  EXTERNAL_FAN_CONTROL: 'external_fan_control',
+  // Info
+  MAX_POWER_DETECTION: 'max_power_detection',
+  MAX_HASHRATE_DETECTION: 'max_hashrate_detection',
+  DEVICE_INFO_DETECTION: 'device_info_detection',
 } as const;
 
 export type MinerFeatureType = typeof MinerFeatureType[keyof typeof MinerFeatureType];

--- a/src/core/models/miner.ts
+++ b/src/core/models/miner.ts
@@ -46,17 +46,56 @@ export interface Miner {
   controller_ids?: string[];
 }
 
+// Temperature value object
+export interface Temperature {
+  value: number;
+  unit: string; // e.g., '°C'
+}
+
+// Fan speed value object
+export interface FanSpeed {
+  value: number;
+  unit: string; // e.g., 'RPM'
+}
+
+// Voltage value object
+export interface Voltage {
+  value: number;
+  unit: string; // e.g., 'V'
+}
+
+// Frequency value object
+export interface Frequency {
+  value: number;
+  unit: string; // e.g., 'MHz'
+}
+
+// Hashboard snapshot
+export interface HashboardSnapshot {
+  index: number;
+  chip_temperature?: Temperature;
+  board_temperature?: Temperature;
+  voltage?: Voltage;
+  frequency?: Frequency;
+  hash_rate?: HashRate;
+  nominal_hash_rate?: HashRate;
+  hash_rate_error?: HashRate;
+}
+
 // Runtime operational state
 export interface MinerStateSnapshot {
   status: MinerStatus;
   hash_rate?: HashRate;
   power_consumption?: number;
-  temperature_board?: number;
-  temperature_chip?: number;
-  temperature_intake?: number;
-  temperature_exhaust?: number;
-  fan_speed_internal?: number;
-  fan_speed_psu?: number;
-  voltage?: number;
-  frequency?: number;
+  inlet_temperature?: Temperature;
+  outlet_temperature?: Temperature;
+  internal_fan_speed: FanSpeed[];
+  external_fan_speed?: FanSpeed;
+  hashboards: HashboardSnapshot[];
+  blocks_found?: number;
+  system_uptime?: number;
+  max_chip_temperature?: Temperature;
+  max_board_temperature?: Temperature;
+  avg_chip_temperature?: Temperature;
+  avg_board_temperature?: Temperature;
 }

--- a/src/core/models/miner.ts
+++ b/src/core/models/miner.ts
@@ -85,6 +85,18 @@ export interface HashboardSnapshot {
   hash_rate_error?: HashRate;
 }
 
+// Miner device information (from DeviceInfoPort)
+export interface MinerInfo {
+  model?: string;
+  serial_number?: string;
+  firmware_version?: string;
+  mac_address?: string;
+  hostname?: string;
+  hashboard_count?: number;
+  chip_count?: number;
+  fan_count?: number;
+}
+
 // Miner limits (max power and hash rate from detection ports)
 export interface MinerLimit {
   max_power?: number;

--- a/src/core/models/miner.ts
+++ b/src/core/models/miner.ts
@@ -82,6 +82,12 @@ export interface HashboardSnapshot {
   hash_rate_error?: HashRate;
 }
 
+// Miner limits (max power and hash rate from detection ports)
+export interface MinerLimit {
+  max_power?: number;
+  max_hash_rate?: HashRate;
+}
+
 // Runtime operational state
 export interface MinerStateSnapshot {
   status: MinerStatus;

--- a/src/core/services/minerService.ts
+++ b/src/core/services/minerService.ts
@@ -1,5 +1,5 @@
 import { BaseService } from "./baseService";
-import type { Miner, MinerLimit, MinerStateSnapshot } from "../models/miner";
+import type { Miner, MinerInfo, MinerLimit, MinerStateSnapshot } from "../models/miner";
 
 export class MinerService extends BaseService {
   getMiners(): Promise<Miner[]> {
@@ -64,5 +64,9 @@ export class MinerService extends BaseService {
 
   getMinerLimits(minerId: string): Promise<MinerLimit> {
     return this.get<MinerLimit>(`/miners/${minerId}/limits`).getData();
+  }
+
+  getMinerInfo(minerId: string): Promise<MinerInfo | null> {
+    return this.get<MinerInfo | null>(`/miners/${minerId}/info`).getData();
   }
 }

--- a/src/core/services/minerService.ts
+++ b/src/core/services/minerService.ts
@@ -1,5 +1,5 @@
 import { BaseService } from "./baseService";
-import type { Miner, MinerFeature, MinerStateSnapshot } from "../models/miner";
+import type { Miner, MinerStateSnapshot } from "../models/miner";
 
 export class MinerService extends BaseService {
   getMiners(): Promise<Miner[]> {
@@ -51,11 +51,11 @@ export class MinerService extends BaseService {
   }
 
   enableFeature(minerId: string, controllerId: string, featureType: string): Promise<Miner> {
-    return this.post<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/enable`).getData();
+    return this.post<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/enable`, {}).getData();
   }
 
   disableFeature(minerId: string, controllerId: string, featureType: string): Promise<Miner> {
-    return this.post<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/disable`).getData();
+    return this.post<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/disable`, {}).getData();
   }
 
   setFeaturePriority(minerId: string, controllerId: string, featureType: string, priority: number): Promise<Miner> {

--- a/src/core/services/minerService.ts
+++ b/src/core/services/minerService.ts
@@ -1,5 +1,5 @@
 import { BaseService } from "./baseService";
-import type { Miner, MinerStateSnapshot } from "../models/miner";
+import type { Miner, MinerFeature, MinerStateSnapshot } from "../models/miner";
 
 export class MinerService extends BaseService {
   getMiners(): Promise<Miner[]> {
@@ -48,5 +48,17 @@ export class MinerService extends BaseService {
 
   unlinkMinerController(minerId: string, controllerId: string): Promise<Miner> {
     return this.post<Miner>(`/miners/${minerId}/unlink-controller`, {}, { params: { controller_id: controllerId } }).getData();
+  }
+
+  enableFeature(minerId: string, controllerId: string, featureType: string): Promise<Miner> {
+    return this.post<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/enable`).getData();
+  }
+
+  disableFeature(minerId: string, controllerId: string, featureType: string): Promise<Miner> {
+    return this.post<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/disable`).getData();
+  }
+
+  setFeaturePriority(minerId: string, controllerId: string, featureType: string, priority: number): Promise<Miner> {
+    return this.put<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/priority`, { priority }).getData();
   }
 }

--- a/src/core/services/minerService.ts
+++ b/src/core/services/minerService.ts
@@ -43,6 +43,10 @@ export class MinerService extends BaseService {
   }
 
   setMinerController(minerId: string, controllerId: string): Promise<Miner> {
-    return this.post<Miner>(`/miners/${minerId}/set-controller`, { controller_id: controllerId }).getData();
+    return this.post<Miner>(`/miners/${minerId}/set-controller`, {}, { params: { controller_id: controllerId } }).getData();
+  }
+
+  unlinkMinerController(minerId: string, controllerId: string): Promise<Miner> {
+    return this.post<Miner>(`/miners/${minerId}/unlink-controller`, {}, { params: { controller_id: controllerId } }).getData();
   }
 }

--- a/src/core/services/minerService.ts
+++ b/src/core/services/minerService.ts
@@ -1,5 +1,5 @@
 import { BaseService } from "./baseService";
-import type { Miner, MinerStateSnapshot } from "../models/miner";
+import type { Miner, MinerLimit, MinerStateSnapshot } from "../models/miner";
 
 export class MinerService extends BaseService {
   getMiners(): Promise<Miner[]> {
@@ -60,5 +60,9 @@ export class MinerService extends BaseService {
 
   setFeaturePriority(minerId: string, controllerId: string, featureType: string, priority: number): Promise<Miner> {
     return this.put<Miner>(`/miners/${minerId}/features/${controllerId}/${featureType}/priority`, { priority }).getData();
+  }
+
+  getMinerLimits(minerId: string): Promise<MinerLimit> {
+    return this.get<MinerLimit>(`/miners/${minerId}/limits`).getData();
   }
 }

--- a/src/core/stores/dashboardStore.ts
+++ b/src/core/stores/dashboardStore.ts
@@ -34,6 +34,10 @@ export const useDashboardStore = defineStore("dashboard", () => {
   const batteryPowerSeries = ref<TimeSeriesPoint[]>([]);
   const gridPowerSeries = ref<TimeSeriesPoint[]>([]);
   const consumptionSeries = ref<TimeSeriesPoint[]>([]);
+  const maxChipTempSeries = ref<TimeSeriesPoint[]>([]);
+  const maxBoardTempSeries = ref<TimeSeriesPoint[]>([]);
+  const internalFanSpeedSeries = ref<TimeSeriesPoint[]>([]);
+  const externalFanSpeedSeries = ref<TimeSeriesPoint[]>([]);
   const events = ref<DashboardEvent[]>([]);
   const minerOnOffEvents = ref<MinerOnOffEvent[]>([]);
   const previousMinerStatuses = ref<Map<string, string>>(new Map());
@@ -41,7 +45,7 @@ export const useDashboardStore = defineStore("dashboard", () => {
   const forecastPowerPoints = ref<ForecastPowerPoint[]>([]);
   let eventCounter = 0;
 
-  type SeriesName = "hashRate" | "power" | "energyProduction" | "batterySOC" | "batteryPower" | "gridPower" | "consumption";
+  type SeriesName = "hashRate" | "power" | "energyProduction" | "batterySOC" | "batteryPower" | "gridPower" | "consumption" | "maxChipTemp" | "maxBoardTemp" | "internalFanSpeed" | "externalFanSpeed";
 
   const seriesMap: Record<SeriesName, typeof hashRateSeries> = {
     hashRate: hashRateSeries,
@@ -51,6 +55,10 @@ export const useDashboardStore = defineStore("dashboard", () => {
     batteryPower: batteryPowerSeries,
     gridPower: gridPowerSeries,
     consumption: consumptionSeries,
+    maxChipTemp: maxChipTempSeries,
+    maxBoardTemp: maxBoardTempSeries,
+    internalFanSpeed: internalFanSpeedSeries,
+    externalFanSpeed: externalFanSpeedSeries,
   };
 
   function addSeriesPoint(
@@ -87,6 +95,10 @@ export const useDashboardStore = defineStore("dashboard", () => {
     batteryPowerSeries,
     gridPowerSeries,
     consumptionSeries,
+    maxChipTempSeries,
+    maxBoardTempSeries,
+    internalFanSpeedSeries,
+    externalFanSpeedSeries,
     events,
     minerOnOffEvents,
     previousMinerStatuses,

--- a/src/core/stores/minerStore.ts
+++ b/src/core/stores/minerStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import type { Miner, MinerStateSnapshot } from "../models/miner";
+import type { Miner, MinerFeature, MinerStateSnapshot } from "../models/miner";
 import { MinerService } from "../services/minerService";
 
 export const useMinerStore = defineStore("miner", () => {
@@ -67,6 +67,18 @@ export const useMinerStore = defineStore("miner", () => {
     return service.unlinkMinerController(minerId, controllerId);
   }
 
+  function enableFeature(minerId: string, controllerId: string, featureType: string) {
+    return service.enableFeature(minerId, controllerId, featureType);
+  }
+
+  function disableFeature(minerId: string, controllerId: string, featureType: string) {
+    return service.disableFeature(minerId, controllerId, featureType);
+  }
+
+  function setFeaturePriority(minerId: string, controllerId: string, featureType: string, priority: number) {
+    return service.setFeaturePriority(minerId, controllerId, featureType, priority);
+  }
+
   return {
     //STATE
     miners,
@@ -84,5 +96,8 @@ export const useMinerStore = defineStore("miner", () => {
     getMinerState,
     setMinerController,
     unlinkMinerController,
+    enableFeature,
+    disableFeature,
+    setFeaturePriority,
   };
 });

--- a/src/core/stores/minerStore.ts
+++ b/src/core/stores/minerStore.ts
@@ -59,6 +59,14 @@ export const useMinerStore = defineStore("miner", () => {
     return minerStates.value.get(minerId);
   }
 
+  function setMinerController(minerId: string, controllerId: string) {
+    return service.setMinerController(minerId, controllerId);
+  }
+
+  function unlinkMinerController(minerId: string, controllerId: string) {
+    return service.unlinkMinerController(minerId, controllerId);
+  }
+
   return {
     //STATE
     miners,
@@ -74,5 +82,7 @@ export const useMinerStore = defineStore("miner", () => {
     deactivateMiner,
     getMinerStatus,
     getMinerState,
+    setMinerController,
+    unlinkMinerController,
   };
 });

--- a/src/core/stores/minerStore.ts
+++ b/src/core/stores/minerStore.ts
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 import { ref } from "vue";
-import type { Miner, MinerFeature, MinerStateSnapshot } from "../models/miner";
+import type { Miner, MinerStateSnapshot } from "../models/miner";
 import { MinerService } from "../services/minerService";
 
 export const useMinerStore = defineStore("miner", () => {

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -12,6 +12,10 @@ const CHART_COLOR_BATTERY = 'rgba(45, 212, 191, 0.9)';   // teal-400
 const CHART_COLOR_BATTERY_POWER = 'rgba(129, 140, 248, 0.9)'; // indigo-400
 const CHART_COLOR_GRID = 'rgba(56, 189, 248, 0.9)';      // sky-400
 const CHART_COLOR_CONSUMPTION = 'rgba(251, 146, 60, 0.9)'; // orange-400
+const CHART_COLOR_CHIP_TEMP = 'rgba(248, 113, 113, 0.9)'; // red-400
+const CHART_COLOR_BOARD_TEMP = 'rgba(251, 146, 60, 0.9)'; // orange-400
+const CHART_COLOR_FAN_INTERNAL = 'rgba(56, 189, 248, 0.9)'; // sky-400
+const CHART_COLOR_FAN_EXTERNAL = 'rgba(129, 140, 248, 0.9)'; // indigo-400
 import KpiCard from "../components/dashboard/KpiCard.vue";
 import MinerTile from "../components/dashboard/MinerTile.vue";
 import ChartPanel from "../components/dashboard/ChartPanel.vue";
@@ -20,6 +24,7 @@ import ActivityFeed from "../components/dashboard/ActivityFeed.vue";
 import SunCard from "../components/dashboard/SunCard.vue";
 import ForecastSummaryCard from "../components/dashboard/ForecastSummaryCard.vue";
 import ForecastChart from "../components/dashboard/ForecastChart.vue";
+import TempFanChart from "../components/dashboard/TempFanChart.vue";
 import type { ForecastIntervalData } from "../components/dashboard/ForecastChart.vue";
 import {
   PhCpu,
@@ -36,11 +41,12 @@ import {
   PhHouseLine,
   PhThermometer,
   PhCloudSun,
+  PhWind,
 } from "@phosphor-icons/vue";
 
 const minerStore = useMinerStore();
 const optimizationUnitStore = useOptimizationUnitStore();
-const { lastUpdated, isPolling, events, hashRateSeries, powerSeries, energyProductionSeries, batterySOCSeries, batteryPowerSeries, gridPowerSeries, consumptionSeries, minerOnOffEvents, forecastPowerPoints, latestDecisionalContexts } = useDashboardPolling(5000);
+const { lastUpdated, isPolling, events, hashRateSeries, powerSeries, energyProductionSeries, batterySOCSeries, batteryPowerSeries, gridPowerSeries, consumptionSeries, maxChipTempSeries, maxBoardTempSeries, internalFanSpeedSeries, externalFanSpeedSeries, minerOnOffEvents, forecastPowerPoints, latestDecisionalContexts } = useDashboardPolling(5000);
 
 // ---------- KPI computations ----------
 
@@ -127,6 +133,14 @@ function formatBatteryValue(v: number): string {
   return `${Math.round(v)}%`;
 }
 
+function formatTemperatureValue(v: number): string {
+  return `${v.toFixed(1)} °C`;
+}
+
+function formatFanSpeedValue(v: number): string {
+  return `${Math.round(v)} RPM`;
+}
+
 
 // Energy KPIs from latest decisional contexts
 const latestEnergyProduction = computed(() => {
@@ -147,6 +161,14 @@ const latestGridPower = computed(() => {
 const latestConsumption = computed(() => {
   const last = consumptionSeries.value;
   return last.length > 0 ? last[last.length - 1].value : 0;
+});
+
+// Check if temperature or fan data is available
+const hasTempFanData = computed(() => {
+  return maxChipTempSeries.value.length > 1 ||
+    maxBoardTempSeries.value.length > 1 ||
+    internalFanSpeedSeries.value.length > 1 ||
+    externalFanSpeedSeries.value.length > 1;
 });
 
 // Forecast chart data: energy (Wh) per interval + max power per interval
@@ -321,11 +343,27 @@ const forecastIntervalData = computed<ForecastIntervalData[]>(() => {
               />
             </ChartPanel>
             <ChartPanel
-              title="Temperature"
+              title="Temperature & Fan"
               :icon="PhThermometer"
               icon-color="text-red-400"
               :chart-height="160"
-            />
+              :has-data="hasTempFanData"
+              :show-marker-toggle="false"
+              v-slot="{ expanded, expandedHeight }"
+            >
+              <TempFanChart
+                v-if="hasTempFanData"
+                :chip-temp-data="maxChipTempSeries"
+                :board-temp-data="maxBoardTempSeries"
+                :internal-fan-data="internalFanSpeedSeries"
+                :external-fan-data="externalFanSpeedSeries"
+                :height="expanded ? expandedHeight : 136"
+                :chip-temp-color="CHART_COLOR_CHIP_TEMP"
+                :board-temp-color="CHART_COLOR_BOARD_TEMP"
+                :internal-fan-color="CHART_COLOR_FAN_INTERNAL"
+                :external-fan-color="CHART_COLOR_FAN_EXTERNAL"
+              />
+            </ChartPanel>
           </div>
         </div>
 

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -41,7 +41,6 @@ import {
   PhHouseLine,
   PhThermometer,
   PhCloudSun,
-  PhWind,
 } from "@phosphor-icons/vue";
 
 const minerStore = useMinerStore();
@@ -131,14 +130,6 @@ function formatPowerValue(v: number): string {
 
 function formatBatteryValue(v: number): string {
   return `${Math.round(v)}%`;
-}
-
-function formatTemperatureValue(v: number): string {
-  return `${v.toFixed(1)} °C`;
-}
-
-function formatFanSpeedValue(v: number): string {
-  return `${Math.round(v)} RPM`;
 }
 
 

--- a/src/views/settings/MinerControllersSettingsView.vue
+++ b/src/views/settings/MinerControllersSettingsView.vue
@@ -70,7 +70,7 @@ const stats = computed(() => {
 
   // Count total assigned miners
   const assignedMinersCount = minerStore.miners.filter(
-    (m) => m.controller_id
+    (m) => m.controller_ids?.length
   ).length;
 
   // Count by adapter type

--- a/src/views/settings/MinersSettingsView.vue
+++ b/src/views/settings/MinersSettingsView.vue
@@ -148,11 +148,25 @@ function handleCloseModal() {
   editingMiner.value = undefined;
 }
 
-function handleSave(miner: Miner) {
+async function applyControllerChanges(minerId: string, changes: { add: string[]; remove: string[] }) {
+  const promises: Promise<any>[] = [];
+  for (const controllerId of changes.add) {
+    promises.push(minerStore.setMinerController(minerId, controllerId));
+  }
+  for (const controllerId of changes.remove) {
+    promises.push(minerStore.unlinkMinerController(minerId, controllerId));
+  }
+  if (promises.length > 0) {
+    await Promise.all(promises);
+  }
+}
+
+function handleSave(miner: Miner, controllerChanges: { add: string[]; remove: string[] }) {
   if (isEditMode.value && miner.id) {
     minerStore
       .updateMiner(miner.id.toString(), miner)
-      .then(() => {
+      .then(async () => {
+        await applyControllerChanges(miner.id!.toString(), controllerChanges);
         minerStore.loadMiners();
         handleCloseModal();
       })
@@ -163,7 +177,10 @@ function handleSave(miner: Miner) {
   } else {
     minerStore
       .addMiner(miner)
-      .then(() => {
+      .then(async (created) => {
+        if (created.id) {
+          await applyControllerChanges(created.id.toString(), controllerChanges);
+        }
         minerStore.loadMiners();
         handleCloseModal();
       })

--- a/src/views/settings/MinersSettingsView.vue
+++ b/src/views/settings/MinersSettingsView.vue
@@ -4,7 +4,7 @@ import { useMinerStore } from "../../core/stores/minerStore";
 import { useMinerControllerStore } from "../../core/stores/minerControllerStore";
 import MinerCard from "../../components/miners/MinerCard.vue";
 import MinerFormModal from "../../components/miners/MinerFormModal.vue";
-import type { Miner, MinerStatus } from "../../core/models/miner";
+import type { Miner, MinerFeature, MinerStatus } from "../../core/models/miner";
 import {
   PhPlus,
   PhPower,
@@ -161,12 +161,37 @@ async function applyControllerChanges(minerId: string, changes: { add: string[];
   }
 }
 
-function handleSave(miner: Miner, controllerChanges: { add: string[]; remove: string[] }) {
+async function applyFeatureChanges(minerId: string, features: MinerFeature[], originalMiner?: Miner) {
+  const originalFeatures = originalMiner?.features ?? [];
+  const promises: Promise<any>[] = [];
+  for (const feature of features) {
+    const original = originalFeatures.find(
+      (f) => f.feature_type === feature.feature_type && f.controller_id === feature.controller_id
+    );
+    if (!original) continue; // New features are auto-created by set-controller
+    if (feature.enabled !== original.enabled) {
+      if (feature.enabled) {
+        promises.push(minerStore.enableFeature(minerId, feature.controller_id, feature.feature_type));
+      } else {
+        promises.push(minerStore.disableFeature(minerId, feature.controller_id, feature.feature_type));
+      }
+    }
+    if (feature.priority !== original.priority) {
+      promises.push(minerStore.setFeaturePriority(minerId, feature.controller_id, feature.feature_type, feature.priority));
+    }
+  }
+  if (promises.length > 0) {
+    await Promise.all(promises);
+  }
+}
+
+function handleSave(miner: Miner, controllerChanges: { add: string[]; remove: string[] }, featureUpdates: MinerFeature[]) {
   if (isEditMode.value && miner.id) {
     minerStore
       .updateMiner(miner.id.toString(), miner)
       .then(async () => {
         await applyControllerChanges(miner.id!.toString(), controllerChanges);
+        await applyFeatureChanges(miner.id!.toString(), featureUpdates, editingMiner.value);
         minerStore.loadMiners();
         handleCloseModal();
       })


### PR DESCRIPTION
## Summary

Adapts the frontend to the **feature-based architecture** implemented in the backend, where each miner can have multiple controllers, each providing a subset of features (monitoring, control, model detection, etc.).

This PR closes #30.

The backend removed `Miner.controller_id`, replacing it with `Miner.features: MinerFeature[]` and `Miner.controller_ids: string[]`. All API payloads and endpoints changed accordingly. The frontend was completely non-functional: creating or editing miners returned 422 errors, the dashboard polling was broken, and controller assignment statistics were wrong.

## Architecture

Previously, a miner had a single optional `controller_id` pointing to one controller. The form used a simple select dropdown, the card showed one controller name in the footer, and the `set-controller` endpoint received the controller ID in the request body.

Now, a miner exposes a `features[]` array where each entry links a `feature_type` to a `controller_id` with a `priority` and `enabled` flag. The derived `controller_ids[]` field lists all associated controllers. Controller binding and unbinding happen through dedicated endpoints (`set-controller` and `unlink-controller`) that accept the controller ID as a query parameter. The form allows adding and removing controllers from a managed list, and each miner parameter (model, hash rate, power) has its own fetch button that resolves which controller to query based on the feature mapping.

## Changes

### Data layer

The `Miner` model in `src/core/models/miner.ts` drops the old `controller_id` field and gains `features?: MinerFeature[]` and `controller_ids?: string[]`. A new `MinerFeatureType` const object enumerates all 16 feature types (hashrate monitoring, power monitoring, temperature sensors, fan speed, voltage, frequency, mining/power/frequency/fan control, model detection). `MinerStateSnapshot` is enriched with 8 additional optional fields to match.

At the service level (`src/core/services/minerService.ts`), `setMinerController()` was fixed to send `controller_id` as a query parameter — it was previously sent as a JSON body, which caused 422 errors. A new `unlinkMinerController()` method handles `POST /miners/{id}/unlink-controller?controller_id=...`. Both actions are exposed through corresponding Pinia store actions in `src/core/stores/minerStore.ts`.

### Miner card

`MinerCard.vue` replaces the single `minerController` computed with a `minerControllers` array derived from `controller_ids`. The footer now shows all controller names comma-separated, with a dynamic "Controller"/"Controllers" label. A `hasController` computed gates the start, stop, and refresh buttons.

<img width="551" height="334" alt="image" src="https://github.com/user-attachments/assets/ab480cc5-b147-498a-9b67-caa279dc91a7" />

### Miner form

`MinerFormModal.vue` received the most significant rewrite. The single controller dropdown is replaced by an add/remove list backed by `selectedControllerIds[]`. The form computes a diff (`controllerChanges`) between the original and current controller sets so that the parent view can apply only the necessary `set-controller`/`unlink-controller` calls after saving the miner payload (which no longer includes `features` or `controller_ids`).

An exclusivity constraint ensures that controllers already assigned to other miners do not appear in the dropdown. Each controller in the list and in the dropdowns displays a colored badge indicating its adapter type (dummy, pyasic, HA), using the same color scheme as `MinerControllerCard`.

For each fetchable miner field (Model, Hash Rate, Power), a fetch button appears only when at least one selected controller provides the corresponding feature. If multiple controllers provide the same feature, the button becomes a dropdown letting the user choose which controller to query. Feature resolution filters `miner.features` by type and enabled status, restricts to currently selected controllers, and sorts by priority.

<img width="688" height="723" alt="image" src="https://github.com/user-attachments/assets/36c9d4f7-21b4-4d03-888c-91e61d028463" />

The _Manage Features_ button allows to manage the priority of the features provided by the controllers, in case multiple controllers provide the same functionality, or to deactivate it.

<img width="569" height="777" alt="image" src="https://github.com/user-attachments/assets/007262df-31e6-4d45-8ebd-199be47da945" />


### Settings views and controller cards

In `MinerControllerCard.vue`, the `assignedMiners` filter switches from `miner.controller_id === id` to `miner.controller_ids?.includes(id)`. The `MinerControllersSettingsView` stat counter follows the same migration. `MinersSettingsView` gains an `applyControllerChanges()` helper that runs all binding/unbinding operations in parallel after the miner save completes, using the diff emitted by the form.

### Dashboard polling

In `useDashboardPolling.ts`, the pollable miners filter changes from checking `m.controller_id` to `m.controller_ids?.length`, so that miners with any assigned controller are polled for status updates.

## Breaking changes

The `Miner` interface no longer has `controller_id` — all references are migrated to `controller_ids[]` and `features[]`. The `save` event of `MinerFormModal` now emits `(miner, controllerChanges)` instead of just `(miner)`, and controller binding is handled post-save through dedicated API calls rather than being included in the miner payload.

