### PR TITLE
Mining Performance

### DIFF
--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -24,9 +24,11 @@ const isEnergyActive = computed(() =>
 );
 
 const isMiningActive = computed(() =>
-  ["/settings/miners", "/settings/miner-controllers"].some((p) =>
-    route.path.startsWith(p)
-  )
+  [
+    "/settings/miners",
+    "/settings/miner-controllers",
+    "/settings/performance-trackers",
+  ].some((p) => route.path.startsWith(p))
 );
 
 const isAutomationActive = computed(() =>
@@ -172,6 +174,15 @@ const isAutomationActive = computed(() =>
                     active-class="active text-primary"
                   >
                     Miner Controllers
+                  </RouterLink>
+                </li>
+                <li class="w-full">
+                  <RouterLink
+                    to="/settings/performance-trackers"
+                    class="w-full text-sm"
+                    active-class="active text-primary"
+                  >
+                    Performance Trackers
                   </RouterLink>
                 </li>
               </ul>

--- a/src/components/SidebarMenu.vue
+++ b/src/components/SidebarMenu.vue
@@ -13,9 +13,14 @@ import VectorIcon from "./VectorIcon.vue";
 
 const route = useRoute();
 
+const isDashboardOpen = ref(true);
 const isEnergyOpen = ref(true);
 const isMiningOpen = ref(true);
 const isAutomationOpen = ref(true);
+
+const isDashboardActive = computed(() =>
+  route.path === "/" || route.path.startsWith("/dashboard")
+);
 
 const isEnergyActive = computed(() =>
   ["/settings/energy-sources", "/settings/energy-monitors", "/settings/forecast-providers"].some(
@@ -58,15 +63,37 @@ const isAutomationActive = computed(() =>
         <ul class="menu px-0 w-full gap-0.5">
           <!-- Dashboard -->
           <li class="w-full">
-            <RouterLink
-              to="/"
-              class="w-full text-sm font-medium"
-              active-class="active text-primary"
-              exact
-            >
-              <PhPulse :size="18" />
-              Dashboard
-            </RouterLink>
+            <details :open="isDashboardOpen">
+              <summary
+                class="text-sm font-medium"
+                :class="{ 'text-primary': isDashboardActive }"
+                @click.prevent="isDashboardOpen = !isDashboardOpen"
+              >
+                <PhPulse :size="18" />
+                Dashboard
+              </summary>
+              <ul class="rounded-t-none p-2 w-full">
+                <li class="w-full">
+                  <RouterLink
+                    to="/"
+                    class="w-full text-sm"
+                    active-class="active text-primary"
+                    exact
+                  >
+                    Overview
+                  </RouterLink>
+                </li>
+                <li class="w-full">
+                  <RouterLink
+                    to="/dashboard/mining"
+                    class="w-full text-sm"
+                    active-class="active text-primary"
+                  >
+                    Mining
+                  </RouterLink>
+                </li>
+              </ul>
+            </details>
           </li>
 
           <!-- Optimization -->

--- a/src/components/mining/MinerStateCard.vue
+++ b/src/components/mining/MinerStateCard.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  PhCpu,
+  PhLightning,
+  PhThermometer,
+  PhFan,
+  PhCube,
+  PhClock,
+} from "@phosphor-icons/vue";
+import type { Miner, MinerStateSnapshot } from "../../core/models/miner";
+import { formatHashRate, formatPower } from "../../core/utils/index";
+
+const props = defineProps<{
+  miner: Miner;
+  state?: MinerStateSnapshot;
+}>();
+
+const isOn = computed(() => props.state?.status === "on");
+
+function formatTemp(value?: number, unit?: string): string {
+  if (value == null) return "-";
+  return `${value.toFixed(1)} ${unit || "°C"}`;
+}
+
+function formatFan(value?: number, unit?: string): string {
+  if (value == null) return "-";
+  return `${Math.round(value)} ${unit || "RPM"}`;
+}
+
+function formatUptime(seconds?: number): string {
+  if (seconds == null) return "-";
+  const d = Math.floor(seconds / 86400);
+  const h = Math.floor((seconds % 86400) / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+</script>
+
+<template>
+  <div class="rounded-xl border border-base-300/20 bg-base-100/30 backdrop-blur-sm overflow-hidden">
+    <div class="flex items-center justify-between px-4 py-3 border-b border-base-300/10">
+      <div class="flex items-center gap-2 min-w-0">
+        <span
+          class="w-2 h-2 rounded-full shrink-0"
+          :class="isOn ? 'bg-emerald-400' : 'bg-base-content/30'"
+        />
+        <span class="text-sm font-medium text-base-content/80 truncate">{{ miner.name }}</span>
+        <span v-if="miner.model" class="text-[10px] text-base-content/40 truncate">
+          {{ miner.model }}
+        </span>
+      </div>
+      <span class="text-[10px] uppercase tracking-wider text-base-content/40">
+        {{ state?.status ?? "unknown" }}
+      </span>
+    </div>
+
+    <div v-if="!state" class="p-4 text-center text-sm text-base-content/30">
+      No runtime state.
+    </div>
+
+    <div v-else class="p-3 grid grid-cols-2 sm:grid-cols-3 gap-2 text-xs">
+      <div class="rounded-lg bg-base-content/5 px-2 py-1.5">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 flex items-center gap-1">
+          <PhCpu :size="11" /> Hash Rate
+        </div>
+        <div class="font-mono text-emerald-400 mt-0.5">
+          {{ formatHashRate(state.hash_rate?.value, state.hash_rate?.unit) }}
+        </div>
+      </div>
+      <div class="rounded-lg bg-base-content/5 px-2 py-1.5">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 flex items-center gap-1">
+          <PhLightning :size="11" /> Power
+        </div>
+        <div class="font-mono text-amber-400 mt-0.5">
+          {{ formatPower(state.power_consumption) }}
+        </div>
+      </div>
+      <div class="rounded-lg bg-base-content/5 px-2 py-1.5">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 flex items-center gap-1">
+          <PhClock :size="11" /> Uptime
+        </div>
+        <div class="font-mono text-base-content/80 mt-0.5">
+          {{ formatUptime(state.system_uptime) }}
+        </div>
+      </div>
+      <div class="rounded-lg bg-base-content/5 px-2 py-1.5">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 flex items-center gap-1">
+          <PhThermometer :size="11" /> Max Chip
+        </div>
+        <div class="font-mono text-red-400 mt-0.5">
+          {{ formatTemp(state.max_chip_temperature?.value, state.max_chip_temperature?.unit) }}
+        </div>
+      </div>
+      <div class="rounded-lg bg-base-content/5 px-2 py-1.5">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 flex items-center gap-1">
+          <PhThermometer :size="11" /> Max Board
+        </div>
+        <div class="font-mono text-orange-400 mt-0.5">
+          {{ formatTemp(state.max_board_temperature?.value, state.max_board_temperature?.unit) }}
+        </div>
+      </div>
+      <div class="rounded-lg bg-base-content/5 px-2 py-1.5">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 flex items-center gap-1">
+          <PhFan :size="11" /> Fan
+        </div>
+        <div class="font-mono text-sky-400 mt-0.5">
+          <template v-if="state.internal_fan_speed?.length">
+            {{ formatFan(Math.max(...state.internal_fan_speed.map((f) => f.value || 0))) }}
+          </template>
+          <template v-else>-</template>
+        </div>
+      </div>
+      <div
+        v-if="state.blocks_found != null"
+        class="rounded-lg bg-base-content/5 px-2 py-1.5"
+      >
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 flex items-center gap-1">
+          <PhCube :size="11" /> Blocks
+        </div>
+        <div class="font-mono text-primary mt-0.5">
+          {{ state.blocks_found }}
+        </div>
+      </div>
+      <div
+        v-if="state.hashboards?.length"
+        class="rounded-lg bg-base-content/5 px-2 py-1.5 col-span-2 sm:col-span-3"
+      >
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1">
+          Hashboards ({{ state.hashboards.length }})
+        </div>
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-1.5">
+          <div
+            v-for="hb in state.hashboards"
+            :key="hb.index"
+            class="rounded bg-base-100/40 border border-base-300/10 px-2 py-1 flex flex-col gap-0.5"
+          >
+            <span class="text-[10px] text-base-content/40">#{{ hb.index }}</span>
+            <span class="text-[11px] font-mono text-emerald-400">
+              {{ formatHashRate(hb.hash_rate?.value, hb.hash_rate?.unit) }}
+            </span>
+            <span class="text-[10px] text-base-content/50">
+              chip {{ formatTemp(hb.chip_temperature?.value, hb.chip_temperature?.unit) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/components/mining/PayoutCard.vue
+++ b/src/components/mining/PayoutCard.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { PhCurrencyBtc, PhClockCountdown, PhCalendar } from "@phosphor-icons/vue";
+import type { MiningPerformanceSnapshot } from "../../core/models/policy";
+import { formatTimeAgo } from "../../core/utils/index";
+
+const props = defineProps<{
+  snapshot: MiningPerformanceSnapshot;
+}>();
+
+const pool = computed(() => props.snapshot.pool_stats);
+const schedule = computed(() => props.snapshot.payout_schedule);
+
+function formatSats(sats: number | null | undefined): string {
+  if (sats == null) return "-";
+  if (Math.abs(sats) >= 100_000_000) {
+    return `${(sats / 100_000_000).toFixed(4)} BTC`;
+  }
+  return `${sats.toLocaleString()} sat`;
+}
+
+function formatFrequency(f?: string | null): string {
+  if (!f) return "-";
+  return f.charAt(0).toUpperCase() + f.slice(1).toLowerCase();
+}
+</script>
+
+<template>
+  <div class="rounded-xl border border-base-300/20 bg-base-100/30 backdrop-blur-sm overflow-hidden">
+    <div class="flex items-center justify-between px-4 py-3 border-b border-base-300/10">
+      <div class="flex items-center gap-2">
+        <PhCurrencyBtc :size="16" class="text-yellow-400" />
+        <span class="text-sm font-medium text-base-content/70">Payout</span>
+      </div>
+    </div>
+
+    <div class="p-4 space-y-3">
+      <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1">
+          Unpaid Balance
+        </div>
+        <div class="text-xl font-bold tabular-nums text-yellow-400">
+          {{ formatSats(pool?.unpaid_balance) }}
+        </div>
+      </div>
+
+      <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2">
+        <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1">
+          Estimated Next Payout
+        </div>
+        <div class="text-base font-bold tabular-nums text-base-content/80">
+          {{ formatSats(pool?.estimated_next_payout) }}
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-2">
+        <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2">
+          <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1 flex items-center gap-1">
+            <PhCalendar :size="11" />
+            Frequency
+          </div>
+          <div class="text-sm font-semibold text-base-content/80">
+            {{ formatFrequency(schedule?.frequency) }}
+          </div>
+        </div>
+        <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2">
+          <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1">
+            Threshold
+          </div>
+          <div class="text-sm font-semibold text-base-content/80">
+            {{ formatSats(schedule?.threshold) }}
+          </div>
+        </div>
+      </div>
+
+      <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2 flex items-center gap-2">
+        <PhClockCountdown :size="14" class="text-teal-400" />
+        <div class="flex-1 min-w-0">
+          <div class="text-[10px] uppercase tracking-wider text-base-content/40">
+            Next Payout
+          </div>
+          <div class="text-sm font-semibold text-base-content/80 truncate">
+            <template v-if="schedule?.next_payout_at">
+              {{ new Date(schedule.next_payout_at).toLocaleString() }}
+              <span class="text-base-content/40 text-xs ml-1">
+                ({{ formatTimeAgo(schedule.next_payout_at) }})
+              </span>
+            </template>
+            <template v-else>-</template>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/components/mining/PoolStatsCard.vue
+++ b/src/components/mining/PoolStatsCard.vue
@@ -1,0 +1,144 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  PhUsersFour,
+  PhCheckCircle,
+  PhWarningCircle,
+  PhXCircle,
+  PhCpu,
+} from "@phosphor-icons/vue";
+import type { MiningPerformanceSnapshot } from "../../core/models/policy";
+import { normalizeHashRate } from "../../core/utils/index";
+import { formatTimeAgo } from "../../core/utils/index";
+
+const props = defineProps<{
+  snapshot: MiningPerformanceSnapshot;
+}>();
+
+function formatHashRate(value?: number | null, unit?: string | null): string {
+  if (value == null) return "-";
+  const th = normalizeHashRate(value, unit || "TH/s");
+  if (th >= 1000) return `${(th / 1000).toFixed(2)} PH/s`;
+  if (th >= 1) return `${th.toFixed(1)} TH/s`;
+  if (th >= 0.001) return `${(th * 1000).toFixed(0)} GH/s`;
+  return `${(th * 1_000_000).toFixed(0)} MH/s`;
+}
+
+const pool = computed(() => props.snapshot.pool_stats);
+const workers = computed(() => pool.value?.workers || []);
+</script>
+
+<template>
+  <div class="rounded-xl border border-base-300/20 bg-base-100/30 backdrop-blur-sm overflow-hidden">
+    <div class="flex items-center justify-between px-4 py-3 border-b border-base-300/10">
+      <div class="flex items-center gap-2">
+        <PhUsersFour :size="16" class="text-sky-400" />
+        <span class="text-sm font-medium text-base-content/70">Pool Stats</span>
+      </div>
+      <span v-if="pool" class="text-[10px] text-base-content/30">
+        {{ formatTimeAgo(pool.timestamp) }}
+      </span>
+    </div>
+
+    <div v-if="!pool" class="p-6 text-center text-sm text-base-content/30">
+      Pool stats not available.
+    </div>
+
+    <div v-else class="p-4 space-y-4">
+      <!-- Hashrate trio -->
+      <div class="grid grid-cols-3 gap-3">
+        <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2">
+          <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1">
+            Current
+          </div>
+          <div class="text-lg font-bold tabular-nums text-primary">
+            {{ formatHashRate(pool.current_hashrate?.value, pool.current_hashrate?.unit) }}
+          </div>
+        </div>
+        <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2">
+          <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1">
+            Avg 24h
+          </div>
+          <div class="text-lg font-bold tabular-nums text-base-content/80">
+            {{ formatHashRate(pool.average_hashrate_24h?.value, pool.average_hashrate_24h?.unit) }}
+          </div>
+        </div>
+        <div class="rounded-lg bg-base-content/5 border border-base-content/10 px-3 py-2">
+          <div class="text-[10px] uppercase tracking-wider text-base-content/40 mb-1">
+            Avg 7d
+          </div>
+          <div class="text-lg font-bold tabular-nums text-base-content/80">
+            {{ formatHashRate(pool.average_hashrate_7d?.value, pool.average_hashrate_7d?.unit) }}
+          </div>
+        </div>
+      </div>
+
+      <!-- Workers list -->
+      <div>
+        <div class="flex items-center justify-between mb-2">
+          <span class="text-[11px] uppercase tracking-wider text-base-content/40">
+            Workers
+          </span>
+          <span class="text-[10px] text-base-content/30">
+            {{ workers.length }} reporting
+          </span>
+        </div>
+
+        <div v-if="workers.length === 0" class="text-center py-4 text-sm text-base-content/30">
+          No workers reported by the pool.
+        </div>
+
+        <div v-else class="space-y-1.5 max-h-[280px] overflow-y-auto">
+          <div
+            v-for="(w, i) in workers"
+            :key="`${w.worker_name}-${i}`"
+            class="flex items-center gap-2 px-2 py-2 rounded-lg border border-base-300/10 bg-base-100/20 text-xs"
+          >
+            <PhCpu :size="14" class="text-base-content/50 shrink-0" />
+            <span class="font-medium text-base-content/80 truncate flex-1 min-w-0">
+              {{ w.worker_name }}
+            </span>
+            <span class="font-mono tabular-nums text-emerald-400 shrink-0">
+              {{ formatHashRate(w.hashrate?.value, w.hashrate?.unit) }}
+            </span>
+            <div class="flex items-center gap-2 text-base-content/50 shrink-0">
+              <span
+                v-if="w.valid_shares != null"
+                class="flex items-center gap-1"
+                :title="`Valid shares: ${w.valid_shares}`"
+              >
+                <PhCheckCircle :size="12" class="text-emerald-400/70" />
+                {{ w.valid_shares }}
+              </span>
+              <span
+                v-if="w.stale_shares != null"
+                class="flex items-center gap-1"
+                :title="`Stale shares: ${w.stale_shares}`"
+              >
+                <PhWarningCircle :size="12" class="text-amber-400/70" />
+                {{ w.stale_shares }}
+              </span>
+              <span
+                v-if="w.rejected_shares != null"
+                class="flex items-center gap-1"
+                :title="`Rejected shares: ${w.rejected_shares}`"
+              >
+                <PhXCircle :size="12" class="text-red-400/70" />
+                {{ w.rejected_shares }}
+              </span>
+            </div>
+            <span
+              v-if="w.last_share_at"
+              class="text-[10px] text-base-content/30 tabular-nums shrink-0"
+              :title="`Last share at ${w.last_share_at}`"
+            >
+              {{ formatTimeAgo(w.last_share_at) }}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/components/optimizationUnits/OptimizationUnitCard.vue
+++ b/src/components/optimizationUnits/OptimizationUnitCard.vue
@@ -5,6 +5,7 @@ import { useMinerStore } from "../../core/stores/minerStore";
 import { useEnergySourceStore } from "../../core/stores/energySourceStore";
 import { useForecastProviderStore } from "../../core/stores/forecastProviderStore";
 import { useNotifierStore } from "../../core/stores/notifierStore";
+import { usePerformanceTrackerStore } from "../../core/stores/performanceTrackerStore";
 import { computed, ref } from "vue";
 import {
   PhPencil,
@@ -13,6 +14,7 @@ import {
   PhCpu,
   PhLightning,
   PhChartLine,
+  PhChartLineUp,
   PhBell,
   PhShieldCheck,
   PhToggleLeft,
@@ -37,6 +39,7 @@ const minerStore = useMinerStore();
 const energySourceStore = useEnergySourceStore();
 const forecastProviderStore = useForecastProviderStore();
 const notifierStore = useNotifierStore();
+const performanceTrackerStore = usePerformanceTrackerStore();
 const showDeleteConfirm = ref(false);
 
 // Resolved references
@@ -56,6 +59,13 @@ const forecastProvider = computed(() => {
   if (!props.unit.home_forecast_provider_id) return null;
   return forecastProviderStore.forecastProviders.find(
     (fp) => fp.id?.toString() === props.unit.home_forecast_provider_id
+  );
+});
+
+const performanceTracker = computed(() => {
+  if (!props.unit.performance_tracker_id) return null;
+  return performanceTrackerStore.performanceTrackers.find(
+    (t) => t.id?.toString() === props.unit.performance_tracker_id
   );
 });
 
@@ -97,6 +107,7 @@ const totalAssignments = computed(() => {
   if (props.unit.policy_id) count++;
   if (props.unit.energy_source_id) count++;
   if (props.unit.home_forecast_provider_id) count++;
+  if (props.unit.performance_tracker_id) count++;
   count += props.unit.target_miner_ids.length;
   count += props.unit.notifier_ids.length;
   return count;
@@ -278,9 +289,22 @@ function handleToggleEnabled() {
             </div>
           </div>
 
+          <!-- Performance Tracker -->
+          <div v-if="performanceTracker" class="flex items-center gap-1.5 min-w-0">
+            <div class="h-6 w-6 rounded-full bg-warning/20 flex items-center justify-center flex-shrink-0">
+              <PhChartLineUp :size="14" class="text-warning" />
+            </div>
+            <div class="min-w-0">
+              <div class="text-[10px] uppercase tracking-wider text-base-content/40">Tracker</div>
+              <div class="text-sm text-base-content/80 leading-tight truncate max-w-[100px]">
+                {{ performanceTracker.name }}
+              </div>
+            </div>
+          </div>
+
           <!-- No assignments fallback -->
           <div
-            v-if="!policy && !energySource && !forecastProvider"
+            v-if="!policy && !energySource && !forecastProvider && !performanceTracker"
             class="text-xs text-base-content/40 italic flex items-center gap-1"
           >
             No resources linked

--- a/src/components/optimizationUnits/OptimizationUnitFormModal.vue
+++ b/src/components/optimizationUnits/OptimizationUnitFormModal.vue
@@ -5,6 +5,7 @@ import { usePolicyStore } from "../../core/stores/policyStore";
 import { useMinerStore } from "../../core/stores/minerStore";
 import { useEnergySourceStore } from "../../core/stores/energySourceStore";
 import { useNotifierStore } from "../../core/stores/notifierStore";
+import { usePerformanceTrackerStore } from "../../core/stores/performanceTrackerStore";
 import {
   PhX,
   PhFloppyDisk,
@@ -12,6 +13,7 @@ import {
   PhCpu,
   PhLightning,
   PhChartLine,
+  PhChartLineUp,
   PhBell,
   PhShieldCheck,
 } from "@phosphor-icons/vue";
@@ -32,6 +34,7 @@ const minerStore = useMinerStore();
 const energySourceStore = useEnergySourceStore();
 //const forecastProviderStore = useForecastProviderStore();
 const notifierStore = useNotifierStore();
+const performanceTrackerStore = usePerformanceTrackerStore();
 
 // Local form state
 const formData = ref({
@@ -40,6 +43,7 @@ const formData = ref({
   policy_id: undefined as string | undefined,
   energy_source_id: undefined as string | undefined,
   home_forecast_provider_id: undefined as string | undefined,
+  performance_tracker_id: undefined as string | undefined,
 });
 
 const selectedMinerIds = ref<string[]>([]);
@@ -57,6 +61,7 @@ watch(
           policy_id: props.unit.policy_id,
           energy_source_id: props.unit.energy_source_id,
           home_forecast_provider_id: props.unit.home_forecast_provider_id,
+          performance_tracker_id: props.unit.performance_tracker_id,
         };
         selectedMinerIds.value = [...props.unit.target_miner_ids];
         selectedNotifierIds.value = [...props.unit.notifier_ids];
@@ -67,6 +72,7 @@ watch(
           policy_id: undefined,
           energy_source_id: undefined,
           home_forecast_provider_id: undefined,
+          performance_tracker_id: undefined,
         };
         selectedMinerIds.value = [];
         selectedNotifierIds.value = [];
@@ -110,6 +116,7 @@ function handleSave() {
     policy_id: formData.value.policy_id,
     energy_source_id: formData.value.energy_source_id,
     home_forecast_provider_id: formData.value.home_forecast_provider_id,
+    performance_tracker_id: formData.value.performance_tracker_id,
     target_miner_ids: selectedMinerIds.value,
     notifier_ids: selectedNotifierIds.value,
   });
@@ -174,7 +181,7 @@ function handleSave() {
           RESOURCE ASSIGNMENTS
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
           <!-- Policy -->
           <div class="form-control">
             <label class="label mb-1">
@@ -232,6 +239,29 @@ function handleSave() {
               >
                 {{ provider.name }}
               </option> -->
+            </select>
+          </div>
+
+          <!-- Performance Tracker -->
+          <div class="form-control">
+            <label class="label mb-1">
+              <span class="label-text flex items-center gap-2">
+                <PhChartLineUp :size="16" class="text-warning" />
+                Performance Tracker
+              </span>
+            </label>
+            <select
+              v-model="formData.performance_tracker_id"
+              class="select select-bordered w-full"
+            >
+              <option :value="undefined">None</option>
+              <option
+                v-for="tracker in performanceTrackerStore.performanceTrackers"
+                :key="tracker.id"
+                :value="tracker.id?.toString()"
+              >
+                {{ tracker.name }}
+              </option>
             </select>
           </div>
         </div>

--- a/src/components/performanceTrackers/PerformanceTrackerCard.vue
+++ b/src/components/performanceTrackers/PerformanceTrackerCard.vue
@@ -1,0 +1,255 @@
+<script setup lang="ts">
+import type {
+  PerformanceTracker,
+  MiningPerformanceTrackerAdapter,
+} from "../../core/models/performanceTracker";
+import type { OptimizationUnit } from "../../core/models/optimizationUnit";
+import { useExternalServiceStore } from "../../core/stores/externalServiceStore";
+import { computed, ref } from "vue";
+import {
+  PhPencil,
+  PhTrash,
+  PhGear,
+  PhLink,
+  PhPlugs,
+  PhChartLineUp,
+  PhWaves,
+  PhBracketsCurly,
+  PhGraph,
+  PhLightning,
+  PhWifiHigh,
+} from "@phosphor-icons/vue";
+import ConfirmDialog from "../ConfirmDialog.vue";
+import EdgeMiningCard, { type CardStyleConfig } from "../EdgeMiningCard.vue";
+import ResourceId from "../ResourceId.vue";
+import { formatType } from "../../core/utils/index";
+
+const props = defineProps<{
+  tracker: PerformanceTracker;
+  allOptimizationUnits?: OptimizationUnit[];
+}>();
+
+const emit = defineEmits<{
+  edit: [tracker: PerformanceTracker];
+  delete: [tracker: PerformanceTracker];
+  test: [tracker: PerformanceTracker];
+}>();
+
+const externalServiceStore = useExternalServiceStore();
+const showDeleteConfirm = ref(false);
+
+const externalService = computed(() => {
+  if (!props.tracker.external_service_id) return null;
+  return externalServiceStore.externalServices.find(
+    (es) => es.id?.toString() === props.tracker.external_service_id
+  );
+});
+
+const linkedOptimizationUnits = computed(() => {
+  if (!props.allOptimizationUnits || !props.tracker.id) return [];
+  return props.allOptimizationUnits.filter(
+    (unit) => unit.performance_tracker_id === props.tracker.id
+  );
+});
+
+const adapterConfig = computed(() => {
+  const type = props.tracker.adapter_type;
+
+  const configs: Record<
+    MiningPerformanceTrackerAdapter,
+    { icon: typeof PhGear; styleConfig: CardStyleConfig; badgeClass: string }
+  > = {
+    dummy: {
+      icon: PhBracketsCurly,
+      badgeClass: "bg-slate-500/20 text-slate-400",
+      styleConfig: {
+        gradient: "hover:from-slate-500/20 hover:to-gray-500/10",
+        iconColor: "text-slate-400",
+        accentBorder: "border-l-base-300/50 hover:border-l-slate-500",
+      },
+    },
+    ocean: {
+      icon: PhWaves,
+      badgeClass: "bg-sky-500/20 text-sky-400",
+      styleConfig: {
+        gradient: "hover:from-sky-500/20 hover:to-blue-500/10",
+        iconColor: "text-sky-400",
+        accentBorder: "border-l-base-300/50 hover:border-l-sky-500",
+      },
+    },
+    braiins_pool: {
+      icon: PhLightning,
+      badgeClass: "bg-amber-500/20 text-amber-400",
+      styleConfig: {
+        gradient: "hover:from-amber-500/20 hover:to-orange-500/10",
+        iconColor: "text-amber-400",
+        accentBorder: "border-l-base-300/50 hover:border-l-amber-500",
+      },
+    },
+  };
+
+  return (
+    configs[type] || {
+      icon: PhChartLineUp,
+      badgeClass: "bg-slate-500/20 text-slate-400",
+      styleConfig: {
+        gradient: "hover:from-slate-500/20 hover:to-gray-500/10",
+        iconColor: "text-slate-400",
+        accentBorder: "border-l-base-300/50 hover:border-l-slate-500",
+      },
+    }
+  );
+});
+
+function handleEdit() {
+  emit("edit", props.tracker);
+}
+
+function handleTestClick() {
+  emit("test", props.tracker);
+}
+
+function handleDeleteClick() {
+  showDeleteConfirm.value = true;
+}
+
+function confirmDelete() {
+  showDeleteConfirm.value = false;
+  emit("delete", props.tracker);
+}
+
+function cancelDelete() {
+  showDeleteConfirm.value = false;
+}
+</script>
+
+<template>
+  <EdgeMiningCard
+    :icon="adapterConfig.icon"
+    :style-config="adapterConfig.styleConfig"
+    card-class="min-h-[220px]"
+  >
+    <!-- Title -->
+    <template #title>
+      {{ tracker.name }}
+    </template>
+
+    <!-- Badges -->
+    <template #badges>
+      <span
+        class="badge badge-sm max-w-[10rem] px-2 overflow-hidden"
+        :class="adapterConfig.badgeClass"
+        :title="formatType(tracker.adapter_type)"
+      >
+        <span class="marquee-on-overflow">{{ formatType(tracker.adapter_type) }}</span>
+      </span>
+
+      <ResourceId v-if="tracker.id" :id="tracker.id" />
+    </template>
+
+    <!-- Actions -->
+    <template #actions>
+      <button
+        class="btn btn-ghost btn-sm btn-square hover:bg-info/20"
+        title="Test connectivity"
+        @click="handleTestClick"
+      >
+        <PhWifiHigh :size="18" class="text-info" />
+      </button>
+      <button
+        class="btn btn-ghost btn-sm btn-square hover:bg-primary/20"
+        title="Edit"
+        @click="handleEdit"
+      >
+        <PhPencil :size="18" class="text-primary" />
+      </button>
+      <button
+        class="btn btn-ghost btn-sm btn-square hover:bg-error/20"
+        title="Delete"
+        @click="handleDeleteClick"
+      >
+        <PhTrash :size="18" class="text-error" />
+      </button>
+    </template>
+
+    <!-- Main Content -->
+    <div class="py-1">
+      <div class="flex items-center gap-2 mb-2">
+        <PhGraph :size="16" class="text-base-content/50" />
+        <span class="text-sm font-medium text-base-content/70">Linked Optimization Units</span>
+      </div>
+
+      <div v-if="linkedOptimizationUnits.length > 0" class="space-y-2">
+        <div class="flex items-center gap-4">
+          <div class="flex items-center gap-1.5">
+            <span class="text-2xl font-bold text-base-content">{{ linkedOptimizationUnits.length }}</span>
+            <span class="text-xs text-base-content/50">linked</span>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-1.5">
+          <span
+            v-for="unit in linkedOptimizationUnits.slice(0, 4)"
+            :key="unit.id"
+            class="badge badge-sm badge-ghost"
+            :class="{ 'badge-success badge-outline': unit.is_enabled }"
+          >
+            {{ unit.name }}
+          </span>
+          <span
+            v-if="linkedOptimizationUnits.length > 4"
+            class="badge badge-sm badge-ghost"
+          >
+            +{{ linkedOptimizationUnits.length - 4 }} more
+          </span>
+        </div>
+      </div>
+
+      <div v-else class="text-sm text-base-content/40 italic py-2">
+        Not linked to any optimization unit
+      </div>
+    </div>
+
+    <!-- Footer -->
+    <template #footer>
+      <div class="flex items-start justify-between gap-2">
+        <div v-if="externalService" class="flex items-center gap-2 min-w-0 flex-shrink">
+          <div class="h-6 w-6 rounded-full bg-info/20 flex items-center justify-center flex-shrink-0">
+            <PhPlugs :size="14" class="text-info" />
+          </div>
+          <div class="min-w-0">
+            <div class="text-[10px] uppercase tracking-wider text-base-content/40">
+              External Service
+            </div>
+            <div class="text-sm text-base-content/80 leading-tight truncate">
+              {{ externalService.name }}
+            </div>
+          </div>
+        </div>
+        <div v-else class="flex items-center gap-2 text-base-content/30">
+          <PhLink :size="14" />
+          <span class="text-xs italic">No service linked</span>
+        </div>
+
+        <div
+          v-if="tracker.config && Object.keys(tracker.config).length > 0"
+          class="flex items-center gap-1 text-xs text-base-content/40 flex-shrink-0"
+          :title="`${Object.keys(tracker.config).length} config properties`"
+        >
+          <PhGear :size="14" />
+          <span>{{ Object.keys(tracker.config).length }} props</span>
+        </div>
+      </div>
+    </template>
+  </EdgeMiningCard>
+
+  <ConfirmDialog
+    :open="showDeleteConfirm"
+    title="Delete Performance Tracker"
+    :message="`Are you sure you want to delete '${tracker.name}'?${linkedOptimizationUnits.length > 0 ? ` This will unlink it from ${linkedOptimizationUnits.length} optimization unit(s).` : ''}`"
+    confirm-text="Delete"
+    variant="danger"
+    @confirm="confirmDelete"
+    @cancel="cancelDelete"
+  />
+</template>

--- a/src/components/performanceTrackers/PerformanceTrackerConfigForm.vue
+++ b/src/components/performanceTrackers/PerformanceTrackerConfigForm.vue
@@ -1,0 +1,255 @@
+<script setup lang="ts">
+import { ref, watch } from "vue";
+import type {
+  ConfigSchema,
+  PerformanceTrackerConfig,
+} from "../../core/models/performanceTracker";
+import { PerformanceTrackerService } from "../../core/services/performanceTrackerService";
+import { PhEye, PhEyeSlash } from "@phosphor-icons/vue";
+
+const props = defineProps<{
+  adapterType: string;
+}>();
+
+const config = defineModel<PerformanceTrackerConfig>({ required: true });
+
+const service = new PerformanceTrackerService();
+const schema = ref<ConfigSchema | null>(null);
+const loading = ref(false);
+const secretVisibility = ref<Record<string, boolean>>({});
+
+const resolveRef = (ref: string, schema: ConfigSchema): any => {
+  if (!ref.startsWith("#/$defs/")) return null;
+  const defName = ref.replace("#/$defs/", "");
+  return schema.$defs?.[defName] || null;
+};
+
+const getPropertySchema = (property: any, schema: ConfigSchema): any => {
+  if (property.$ref) {
+    return resolveRef(property.$ref, schema);
+  }
+
+  if (property.anyOf) {
+    const nonNullType = property.anyOf.find((item: any) => item.type !== "null");
+    if (nonNullType) {
+      if (nonNullType.$ref) {
+        return resolveRef(nonNullType.$ref, schema);
+      }
+      return { ...property, ...nonNullType, anyOf: undefined };
+    }
+  }
+
+  return property;
+};
+
+const isNullable = (property: any): boolean => {
+  if (property.anyOf) {
+    return property.anyOf.some((item: any) => item.type === "null");
+  }
+  return false;
+};
+
+const initializeDefaultValue = (property: any, schema: ConfigSchema): any => {
+  if (property.default !== undefined) {
+    return property.default;
+  }
+  const resolved = getPropertySchema(property, schema);
+
+  if (resolved?.default !== undefined) {
+    return resolved.default;
+  }
+  if (isNullable(property)) {
+    return null;
+  }
+  if (resolved?.enum) {
+    return resolved.enum[0];
+  }
+  if (resolved?.type === "string") return "";
+  if (resolved?.type === "number" || resolved?.type === "integer") return 0;
+  if (resolved?.type === "boolean") return false;
+  return null;
+};
+
+watch(
+  () => props.adapterType,
+  async (newAdapterType) => {
+    if (!newAdapterType) {
+      schema.value = null;
+      return;
+    }
+    loading.value = true;
+    try {
+      schema.value = await service.getConfigSchema(newAdapterType);
+      if (schema.value?.properties) {
+        const existingConfig = { ...config.value };
+        const newConfig: PerformanceTrackerConfig = {};
+        Object.entries(schema.value.properties).forEach(([key, property]) => {
+          if (existingConfig[key] !== undefined) {
+            newConfig[key] = existingConfig[key];
+          } else {
+            newConfig[key] = initializeDefaultValue(property, schema.value!);
+          }
+        });
+        config.value = newConfig;
+      }
+    } catch (error) {
+      console.error("Failed to load performance tracker config schema:", error);
+      schema.value = null;
+    } finally {
+      loading.value = false;
+    }
+  },
+  { immediate: true }
+);
+
+const formatFieldName = (name: string) => {
+  return name
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+};
+
+const isRequired = (fieldName: string) => {
+  return schema.value?.required?.includes(fieldName) || false;
+};
+
+const getFieldType = (property: any, schema: ConfigSchema) => {
+  const resolved = getPropertySchema(property, schema);
+
+  if (resolved?.enum) return "enum";
+  if (resolved?.type === "object" && resolved?.properties) return "object";
+  if (resolved?.type === "integer" || resolved?.type === "number") return "number";
+  if (resolved?.type === "string") return "string";
+  if (resolved?.type === "boolean") return "boolean";
+
+  return "unknown";
+};
+
+const toggleSecretVisibility = (fieldKey: string) => {
+  secretVisibility.value[fieldKey] = !secretVisibility.value[fieldKey];
+};
+
+const isSecretField = (fieldName: string): boolean => {
+  const lower = String(fieldName).toLowerCase();
+  return (
+    lower.includes("password") ||
+    lower.includes("token") ||
+    lower.includes("secret") ||
+    lower.includes("api_key") ||
+    lower.includes("apikey")
+  );
+};
+</script>
+
+<template>
+  <div v-if="loading" class="flex items-center justify-center p-4">
+    <span class="loading loading-spinner loading-md"></span>
+  </div>
+  <div v-else-if="schema && schema.properties" class="flex flex-col gap-4">
+    <div
+      v-for="(property, fieldName) in schema.properties"
+      :key="fieldName"
+      class="space-y-1"
+    >
+      <div class="font-medium">
+        {{ property.title || formatFieldName(String(fieldName)) }}
+        <span
+          v-if="isRequired(String(fieldName))"
+          class="text-sm text-error opacity-60 ml-1 font-normal"
+          >(required)</span
+        >
+        <span
+          v-else
+          class="text-sm opacity-60 ml-1 font-normal"
+          >(optional)</span
+        >
+      </div>
+
+      <!-- Enum select -->
+      <select
+        v-if="getFieldType(property, schema) === 'enum'"
+        v-model="config[fieldName]"
+        :required="isRequired(String(fieldName))"
+        class="select select-bordered select-sm w-full"
+      >
+        <option v-if="isNullable(property)" :value="null">-- None --</option>
+        <option
+          v-for="option in getPropertySchema(property, schema).enum"
+          :key="option"
+          :value="option"
+        >
+          {{ option }}
+        </option>
+      </select>
+
+      <!-- String input -->
+      <div
+        v-else-if="getFieldType(property, schema) === 'string'"
+        class="relative"
+      >
+        <input
+          v-model="config[fieldName]"
+          :type="
+            isSecretField(String(fieldName)) && !secretVisibility[String(fieldName)]
+              ? 'password'
+              : 'text'
+          "
+          :placeholder="property.default || ''"
+          :required="isRequired(String(fieldName))"
+          class="input input-bordered input-sm w-full"
+          :class="{ 'pr-10': isSecretField(String(fieldName)) }"
+        />
+        <button
+          v-if="isSecretField(String(fieldName))"
+          type="button"
+          class="absolute right-2 top-1/2 -translate-y-1/2 btn btn-ghost btn-xs"
+          tabindex="-1"
+          @click="toggleSecretVisibility(String(fieldName))"
+        >
+          <PhEyeSlash v-if="secretVisibility[String(fieldName)]" :size="16" />
+          <PhEye v-else :size="16" />
+        </button>
+      </div>
+
+      <!-- Number input -->
+      <input
+        v-else-if="getFieldType(property, schema) === 'number'"
+        v-model.number="config[fieldName]"
+        type="number"
+        :step="getPropertySchema(property, schema).type === 'integer' ? '1' : 'any'"
+        :min="getPropertySchema(property, schema).minimum"
+        :max="getPropertySchema(property, schema).maximum"
+        :placeholder="property.default"
+        :required="isRequired(String(fieldName))"
+        class="input input-bordered input-sm w-full"
+      />
+
+      <!-- Boolean -->
+      <label
+        v-else-if="getFieldType(property, schema) === 'boolean'"
+        class="flex items-center gap-2 cursor-pointer"
+      >
+        <input
+          v-model="config[fieldName]"
+          type="checkbox"
+          class="checkbox checkbox-sm"
+        />
+        <span class="text-sm">
+          {{ property.description || "Enable" }}
+        </span>
+      </label>
+
+      <!-- Description helper text -->
+      <div
+        v-if="
+          property.description &&
+          getFieldType(property, schema) !== 'boolean' &&
+          getFieldType(property, schema) !== 'object'
+        "
+        class="text-sm italic opacity-70"
+      >
+        {{ property.description }}
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/performanceTrackers/PerformanceTrackerFormModal.vue
+++ b/src/components/performanceTrackers/PerformanceTrackerFormModal.vue
@@ -1,0 +1,324 @@
+<script setup lang="ts">
+import { computed, ref, watch, toRaw } from "vue";
+import {
+  type PerformanceTracker,
+  MiningPerformanceTrackerAdapter,
+} from "../../core/models/performanceTracker";
+import { usePerformanceTrackerStore } from "../../core/stores/performanceTrackerStore";
+import { useExternalServiceStore } from "../../core/stores/externalServiceStore";
+import { PerformanceTrackerService } from "../../core/services/performanceTrackerService";
+import PerformanceTrackerConfigForm from "./PerformanceTrackerConfigForm.vue";
+import {
+  PhX,
+  PhFloppyDisk,
+  PhGear,
+  PhPlugs,
+  PhChartLineUp,
+} from "@phosphor-icons/vue";
+import { formatType } from "../../core/utils/index";
+
+const props = defineProps<{
+  open: boolean;
+  performanceTracker?: PerformanceTracker;
+  isEdit?: boolean;
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  save: [tracker: PerformanceTracker];
+}>();
+
+const performanceTrackerStore = usePerformanceTrackerStore();
+const externalServiceStore = useExternalServiceStore();
+const performanceTrackerService = new PerformanceTrackerService();
+
+const requiredExternalServiceType = ref<string | null>(null);
+const isLoadingExternalServiceType = ref(false);
+
+const formData = ref<PerformanceTracker>({
+  name: "",
+  adapter_type: MiningPerformanceTrackerAdapter.DUMMY,
+  config: {},
+  external_service_id: "",
+});
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (isOpen) {
+      if (props.performanceTracker) {
+        formData.value = {
+          ...props.performanceTracker,
+          config: props.performanceTracker.config
+            ? { ...props.performanceTracker.config }
+            : {},
+          external_service_id:
+            props.performanceTracker.external_service_id || "",
+        };
+      } else {
+        formData.value = {
+          name: "",
+          adapter_type:
+            performanceTrackerStore.adapterTypes[0] ||
+            MiningPerformanceTrackerAdapter.DUMMY,
+          config: {},
+          external_service_id: "",
+        };
+      }
+    }
+  },
+  { immediate: true }
+);
+
+const isFormValid = computed(() => {
+  return (
+    formData.value.name.trim().length > 0 &&
+    formData.value.adapter_type.trim().length > 0
+  );
+});
+
+const isExternalServiceDisabled = computed(() => {
+  return requiredExternalServiceType.value === null;
+});
+
+const filteredExternalServices = computed(() => {
+  if (!requiredExternalServiceType.value) return [];
+  return externalServiceStore.externalServices.filter(
+    (svc) =>
+      svc.adapter_type?.toLowerCase() ===
+      requiredExternalServiceType.value?.toLowerCase()
+  );
+});
+
+watch(
+  () => formData.value.adapter_type,
+  async (newType) => {
+    if (!newType) {
+      requiredExternalServiceType.value = null;
+      return;
+    }
+
+    isLoadingExternalServiceType.value = true;
+    try {
+      requiredExternalServiceType.value =
+        await performanceTrackerService.getExternalServiceType(newType);
+      if (requiredExternalServiceType.value === null) {
+        formData.value.external_service_id = "";
+      }
+    } catch {
+      requiredExternalServiceType.value = null;
+      formData.value.external_service_id = "";
+    } finally {
+      isLoadingExternalServiceType.value = false;
+    }
+  },
+  { immediate: true }
+);
+
+function handleClose() {
+  emit("close");
+}
+
+function cleanTracker(tracker: PerformanceTracker): PerformanceTracker {
+  const cleaned = { ...tracker };
+  if (cleaned.config && Object.keys(cleaned.config).length === 0) {
+    delete cleaned.config;
+  }
+  if (cleaned.external_service_id === "") {
+    delete cleaned.external_service_id;
+  }
+  return cleaned;
+}
+
+function handleSave() {
+  if (isFormValid.value) {
+    const rawData = JSON.parse(JSON.stringify(toRaw(formData.value)));
+    emit("save", cleanTracker(rawData));
+  }
+}
+</script>
+
+<template>
+  <dialog class="modal" :class="{ 'modal-open': open }">
+    <div class="modal-box max-w-2xl bg-base-100 border border-base-300/60">
+      <!-- Header -->
+      <div class="flex items-center justify-between mb-6">
+        <div class="flex items-center gap-3">
+          <div class="h-10 w-10 rounded-xl bg-base-200/60 flex items-center justify-center">
+            <PhChartLineUp :size="22" class="text-warning" />
+          </div>
+          <h3 class="text-xl font-bold">
+            {{ isEdit ? "Edit Performance Tracker" : "Add Performance Tracker" }}
+          </h3>
+        </div>
+        <button class="btn btn-ghost btn-sm btn-square" @click="handleClose">
+          <PhX :size="20" />
+        </button>
+      </div>
+
+      <p class="text-xs text-base-content/50 mb-4">* Required fields</p>
+
+      <form class="space-y-6" @submit.prevent="handleSave">
+        <!-- Basic Info -->
+        <div class="space-y-4">
+          <div class="flex items-center gap-2 text-sm font-semibold text-base-content/70 uppercase tracking-wider">
+            <PhGear :size="16" />
+            Basic Information
+          </div>
+
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="form-control">
+              <label class="label mb-1">
+                <span class="label-text font-medium">Name *</span>
+              </label>
+              <input
+                v-model="formData.name"
+                type="text"
+                placeholder="Enter tracker name"
+                class="input input-bordered w-full"
+                required
+              />
+            </div>
+
+            <div class="form-control">
+              <label class="label mb-1">
+                <span class="label-text font-medium">Adapter Type *</span>
+              </label>
+              <select
+                v-model="formData.adapter_type"
+                class="select select-bordered w-full"
+                :disabled="isEdit"
+                required
+              >
+                <option value="" disabled>Select adapter type</option>
+                <option
+                  v-for="adapterType in performanceTrackerStore.adapterTypes"
+                  :key="adapterType"
+                  :value="adapterType"
+                >
+                  {{ formatType(adapterType) }}
+                </option>
+              </select>
+              <label v-if="isEdit" class="label">
+                <span class="label-text-alt text-base-content/50 italic">
+                  Adapter type cannot be changed after creation
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+
+        <!-- External Service -->
+        <div class="space-y-4" :class="{ 'opacity-50': isExternalServiceDisabled }">
+          <div class="flex items-center gap-2 text-sm font-semibold text-base-content/70 uppercase tracking-wider">
+            <PhPlugs :size="16" />
+            External Service
+          </div>
+
+          <div class="form-control">
+            <label class="label mb-1 flex justify-between items-center">
+              <span class="label-text font-medium">Linked Service</span>
+              <span
+                v-if="requiredExternalServiceType"
+                class="label-text-alt badge badge-sm badge-info"
+              >
+                {{ requiredExternalServiceType }}
+              </span>
+            </label>
+            <select
+              v-model="formData.external_service_id"
+              class="select select-bordered w-full"
+              :disabled="isExternalServiceDisabled || isLoadingExternalServiceType"
+            >
+              <option value="">-- None --</option>
+              <option
+                v-for="svc in filteredExternalServices"
+                :key="svc.id"
+                :value="svc.id"
+              >
+                {{ svc.name }}
+              </option>
+            </select>
+            <label class="label">
+              <span
+                v-if="isLoadingExternalServiceType"
+                class="label-text-alt text-base-content/50 italic"
+                >Loading...</span
+              >
+              <span
+                v-else-if="isExternalServiceDisabled"
+                class="label-text-alt text-base-content/50 italic"
+                >External service not required for this adapter type</span
+              >
+              <span
+                v-else-if="filteredExternalServices.length === 0"
+                class="label-text-alt text-warning italic"
+              >
+                No
+                {{
+                  requiredExternalServiceType
+                    ? formatType(requiredExternalServiceType)
+                    : ""
+                }}
+                services configured
+              </span>
+              <span v-else class="label-text-alt text-base-content/50">
+                Link to a
+                {{
+                  requiredExternalServiceType
+                    ? formatType(requiredExternalServiceType)
+                    : ""
+                }}
+                service for API connectivity
+              </span>
+            </label>
+          </div>
+        </div>
+
+        <!-- Configuration -->
+        <div class="space-y-4">
+          <div class="flex items-center gap-2 text-sm font-semibold text-base-content/70 uppercase tracking-wider">
+            <PhGear :size="16" />
+            Configuration
+          </div>
+
+          <div class="bg-base-200/50 rounded-xl p-4 border border-base-300/40">
+            <PerformanceTrackerConfigForm
+              v-if="formData.config"
+              v-model="formData.config"
+              :adapter-type="formData.adapter_type"
+            />
+            <div v-else class="text-sm text-base-content/50 italic py-4 text-center">
+              Select an adapter type to see configuration options
+            </div>
+          </div>
+        </div>
+
+        <!-- Actions -->
+        <div class="flex justify-end gap-3 pt-4 border-t border-base-300/40">
+          <button type="button" class="btn btn-ghost" @click="handleClose">
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="btn btn-primary gap-2"
+            :disabled="!isFormValid"
+          >
+            <PhFloppyDisk :size="18" />
+            {{ isEdit ? "Save Changes" : "Create Tracker" }}
+          </button>
+        </div>
+      </form>
+    </div>
+
+    <form method="dialog" class="modal-backdrop bg-black/50">
+      <button @click="handleClose">close</button>
+    </form>
+  </dialog>
+</template>
+
+<style scoped>
+.space-y-4:hover .uppercase {
+  color: oklch(var(--bc) / 0.8);
+}
+</style>

--- a/src/core/models/performanceTracker.ts
+++ b/src/core/models/performanceTracker.ts
@@ -1,0 +1,74 @@
+import type { ConfigSchema } from "./minerController";
+
+export const MiningPerformanceTrackerAdapter = {
+  DUMMY: "dummy",
+  OCEAN: "ocean",
+  BRAIINS_POOL: "braiins_pool",
+} as const;
+
+export type MiningPerformanceTrackerAdapter =
+  typeof MiningPerformanceTrackerAdapter[keyof typeof MiningPerformanceTrackerAdapter];
+
+export interface PerformanceTrackerConfig {
+  [key: string]: any;
+}
+
+export interface PerformanceTracker {
+  id?: string;
+  name: string;
+  adapter_type: MiningPerformanceTrackerAdapter;
+  config?: PerformanceTrackerConfig;
+  external_service_id?: string;
+}
+
+export interface HashRate {
+  value: number;
+  unit: string;
+}
+
+export interface PoolWorkerStats {
+  worker_name: string;
+  hashrate?: HashRate | null;
+  last_share_at?: string | null;
+  valid_shares?: number | null;
+  stale_shares?: number | null;
+  rejected_shares?: number | null;
+}
+
+export interface PoolStats {
+  current_hashrate?: HashRate | null;
+  average_hashrate_24h?: HashRate | null;
+  average_hashrate_7d?: HashRate | null;
+  unpaid_balance?: number | null;
+  estimated_next_payout?: number | null;
+  workers: PoolWorkerStats[];
+  timestamp: string;
+}
+
+export interface MiningReward {
+  amount: number;
+  timestamp: string;
+}
+
+export const PayoutFrequency = {
+  DAILY: "daily",
+  WEEKLY: "weekly",
+  MONTHLY: "monthly",
+  THRESHOLD: "threshold",
+  UNKNOWN: "unknown",
+} as const;
+
+export type PayoutFrequency = typeof PayoutFrequency[keyof typeof PayoutFrequency];
+
+export interface PayoutSchedule {
+  frequency: PayoutFrequency;
+  threshold?: number | null;
+  next_payout_at?: string | null;
+}
+
+export interface TrackerTestResult {
+  status: string;
+  message: string;
+}
+
+export type { ConfigSchema };

--- a/src/core/models/policy.ts
+++ b/src/core/models/policy.ts
@@ -1,7 +1,15 @@
 import type { EnergySource, EnergyStateSnapshot } from "./energySource";
 import type { Forecast, Sun } from "./forecast";
 import type { ConsumptionForecast } from "./homeLoad";
-import type { Miner, HashRate, MinerStateSnapshot } from "./miner";
+import type { Miner, MinerStateSnapshot } from "./miner";
+import type { HashRate, PayoutSchedule, PoolStats } from "./performanceTracker";
+
+export interface MiningPerformanceSnapshot {
+  current_hashrate?: HashRate | null;
+  pool_stats?: PoolStats | null;
+  payout_schedule?: PayoutSchedule | null;
+  timestamp: string; // ISO datetime
+}
 
 export type RuleType = "start" | "stop";
 
@@ -62,7 +70,7 @@ export interface DecisionalContext {
   energy_state?: EnergyStateSnapshot;
   forecast?: Forecast;
   home_load_forecast?: ConsumptionForecast;
-  tracker_current_hashrate?: HashRate;
+  mining_performance?: MiningPerformanceSnapshot;
   sun?: Sun;
   miner?: Miner;
   miner_state?: MinerStateSnapshot;

--- a/src/core/services/performanceTrackerService.ts
+++ b/src/core/services/performanceTrackerService.ts
@@ -1,0 +1,92 @@
+import { BaseService } from "./baseService";
+import type {
+  PerformanceTracker,
+  MiningPerformanceTrackerAdapter,
+  ConfigSchema,
+  PoolStats,
+  PoolWorkerStats,
+  MiningReward,
+  PayoutSchedule,
+  TrackerTestResult,
+} from "../models/performanceTracker";
+
+export class PerformanceTrackerService extends BaseService {
+  getPerformanceTrackers(): Promise<PerformanceTracker[]> {
+    return this.get<PerformanceTracker[]>("/mining-performance-trackers").getData();
+  }
+
+  getPerformanceTracker(trackerId: string): Promise<PerformanceTracker> {
+    return this.get<PerformanceTracker>(`/mining-performance-trackers/${trackerId}`).getData();
+  }
+
+  addPerformanceTracker(tracker: PerformanceTracker): Promise<PerformanceTracker> {
+    return this.post<PerformanceTracker>("/mining-performance-trackers", tracker).getData();
+  }
+
+  updatePerformanceTracker(
+    trackerId: string,
+    tracker: Partial<PerformanceTracker>
+  ): Promise<PerformanceTracker> {
+    return this.put<PerformanceTracker>(
+      `/mining-performance-trackers/${trackerId}`,
+      tracker
+    ).getData();
+  }
+
+  deletePerformanceTracker(trackerId: string): Promise<PerformanceTracker> {
+    return this.delete<PerformanceTracker>(
+      `/mining-performance-trackers/${trackerId}`
+    ).getData();
+  }
+
+  getAdapterTypes(): Promise<MiningPerformanceTrackerAdapter[]> {
+    return this.get<MiningPerformanceTrackerAdapter[]>(
+      "/mining-performance-trackers/types"
+    ).getData();
+  }
+
+  getConfigSchema(adapterType: string): Promise<ConfigSchema> {
+    return this.get<ConfigSchema>(
+      `/mining-performance-trackers/types/${adapterType}/config-schema`
+    ).getData();
+  }
+
+  getExternalServiceType(adapterType: string): Promise<string | null> {
+    return this.get<string>(
+      `/mining-performance-trackers/types/${adapterType}/external-services`
+    )
+      .getData()
+      .then((result) => (result === "null" || result === null ? null : result));
+  }
+
+  testPerformanceTracker(trackerId: string): Promise<TrackerTestResult> {
+    return this.post<TrackerTestResult>(
+      `/mining-performance-trackers/${trackerId}/test`,
+      {}
+    ).getData();
+  }
+
+  getPoolStats(trackerId: string): Promise<PoolStats> {
+    return this.get<PoolStats>(
+      `/mining-performance-trackers/${trackerId}/stats`
+    ).getData();
+  }
+
+  getWorkers(trackerId: string): Promise<PoolWorkerStats[]> {
+    return this.get<PoolWorkerStats[]>(
+      `/mining-performance-trackers/${trackerId}/workers`
+    ).getData();
+  }
+
+  getRewards(trackerId: string, limit = 10): Promise<MiningReward[]> {
+    return this.get<MiningReward[]>(
+      `/mining-performance-trackers/${trackerId}/rewards?limit=${limit}`
+    ).getData();
+  }
+
+  getPayoutSchedule(trackerId: string): Promise<PayoutSchedule> {
+    return this.get<PayoutSchedule>(
+      `/mining-performance-trackers/${trackerId}/payout-schedule`
+    ).getData();
+  }
+}

--- a/src/core/stores/performanceTrackerStore.ts
+++ b/src/core/stores/performanceTrackerStore.ts
@@ -1,0 +1,60 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import type {
+  PerformanceTracker,
+  MiningPerformanceTrackerAdapter,
+} from "../models/performanceTracker";
+import { PerformanceTrackerService } from "../services/performanceTrackerService";
+
+export const usePerformanceTrackerStore = defineStore("performanceTracker", () => {
+  const service = new PerformanceTrackerService();
+
+  // State
+  const performanceTrackers = ref<PerformanceTracker[]>([]);
+  const adapterTypes = ref<MiningPerformanceTrackerAdapter[]>([]);
+
+  // Actions
+  function loadPerformanceTrackers() {
+    return service.getPerformanceTrackers().then((response) => {
+      performanceTrackers.value = response;
+    });
+  }
+
+  function loadAdapterTypes() {
+    return service.getAdapterTypes().then((response) => {
+      adapterTypes.value = response;
+    });
+  }
+
+  function addPerformanceTracker(tracker: PerformanceTracker) {
+    return service.addPerformanceTracker(tracker);
+  }
+
+  function updatePerformanceTracker(
+    trackerId: string,
+    tracker: Partial<PerformanceTracker>
+  ) {
+    return service.updatePerformanceTracker(trackerId, tracker);
+  }
+
+  function deletePerformanceTracker(trackerId: string) {
+    return service.deletePerformanceTracker(trackerId);
+  }
+
+  function testPerformanceTracker(trackerId: string) {
+    return service.testPerformanceTracker(trackerId);
+  }
+
+  return {
+    // STATE
+    performanceTrackers,
+    adapterTypes,
+    // ACTIONS
+    loadPerformanceTrackers,
+    loadAdapterTypes,
+    addPerformanceTracker,
+    updatePerformanceTracker,
+    deletePerformanceTracker,
+    testPerformanceTracker,
+  };
+});

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from "vue-router";
 import DashboardView from "../views/DashboardView.vue";
+import MiningDashboardView from "../views/dashboard/MiningDashboardView.vue";
 import MinersSettingsView from "../views/settings/MinersSettingsView.vue";
 import EnergySourcesSettingsView from "../views/settings/EnergySourcesSettingsView.vue";
 import EnergyMonitorSettingsView from "../views/settings/EnergyMonitorSettingsView.vue";
@@ -19,6 +20,11 @@ const router = createRouter({
       name: "dashboard",
       // This is the default route, it will be replaced by the setHomeRoute function
       component: DashboardView,
+    },
+    {
+      path: "/dashboard/mining",
+      name: "dashboard.mining",
+      component: MiningDashboardView,
     },
     {
       path: "/settings/",

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,7 @@ import MinersSettingsView from "../views/settings/MinersSettingsView.vue";
 import EnergySourcesSettingsView from "../views/settings/EnergySourcesSettingsView.vue";
 import EnergyMonitorSettingsView from "../views/settings/EnergyMonitorSettingsView.vue";
 import MinerControllersSettingsView from "../views/settings/MinerControllersSettingsView.vue";
+import PerformanceTrackersSettingsView from "../views/settings/PerformanceTrackersSettingsView.vue";
 import ForecastProvidersSettingsView from "../views/settings/ForecastProvidersSettingsView.vue";
 import PoliciesSettingsView from "../views/settings/PoliciesSettingsView.vue";
 import NotifiersSettingsView from "../views/settings/NotifiersSettingsView.vue";
@@ -43,6 +44,11 @@ const router = createRouter({
           path: "miner-controllers",
           name: "settings.minerControllers",
           component: MinerControllersSettingsView,
+        },
+        {
+          path: "performance-trackers",
+          name: "settings.performanceTrackers",
+          component: PerformanceTrackersSettingsView,
         },
         {
           path: "forecast-providers",

--- a/src/views/dashboard/MiningDashboardView.vue
+++ b/src/views/dashboard/MiningDashboardView.vue
@@ -1,0 +1,359 @@
+<script setup lang="ts">
+import { computed, ref, onMounted, onUnmounted } from "vue";
+import { useMinerStore } from "../../core/stores/minerStore";
+import { useOptimizationUnitStore } from "../../core/stores/optimizationUnitStore";
+import { useDashboardPolling } from "../../core/composables/useDashboardPolling";
+import { normalizeHashRate, formatPower, formatTimeAgo } from "../../core/utils/index";
+import KpiCard from "../../components/dashboard/KpiCard.vue";
+import MinerTile from "../../components/dashboard/MinerTile.vue";
+import PoolStatsCard from "../../components/mining/PoolStatsCard.vue";
+import PayoutCard from "../../components/mining/PayoutCard.vue";
+import MinerStateCard from "../../components/mining/MinerStateCard.vue";
+import {
+  PhCpu,
+  PhLightning,
+  PhPower,
+  PhArrowsClockwise,
+  PhCurrencyBtc,
+  PhUsersFour,
+  PhClockCountdown,
+  PhTrendUp,
+} from "@phosphor-icons/vue";
+import type { MiningPerformanceSnapshot } from "../../core/models/policy";
+
+const minerStore = useMinerStore();
+const optimizationUnitStore = useOptimizationUnitStore();
+const { lastUpdated, isPolling, latestDecisionalContexts } = useDashboardPolling(5000);
+
+// ---------- Tick for "time ago" reactivity ----------
+const now = ref(Date.now());
+let tickTimer: ReturnType<typeof setInterval> | undefined;
+onMounted(() => { tickTimer = setInterval(() => { now.value = Date.now(); }, 1000); });
+onUnmounted(() => { if (tickTimer) clearInterval(tickTimer); });
+
+const lastUpdateLabel = computed(() => {
+  void now.value;
+  return formatTimeAgo(lastUpdated.value);
+});
+
+// ---------- Miner KPIs (from miner store) ----------
+const totalMiners = computed(() => minerStore.miners.length);
+const runningMiners = computed(
+  () => minerStore.miners.filter((m) => {
+    const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+    return state?.status === "on";
+  }).length
+);
+const activeMiners = computed(
+  () => minerStore.miners.filter((m) => m.active).length
+);
+
+const totalDeviceHashRate = computed(() => {
+  let total = 0;
+  for (const m of minerStore.miners) {
+    const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+    if (state?.status === "on" && state.hash_rate?.value) {
+      total += normalizeHashRate(state.hash_rate.value, state.hash_rate.unit || "TH/s");
+    }
+  }
+  return total;
+});
+
+const totalDevicePower = computed(() => {
+  return minerStore.miners
+    .filter((m) => {
+      const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+      return state?.status === "on";
+    })
+    .reduce((sum, m) => {
+      const state = m.id ? minerStore.minerStates.get(m.id) : undefined;
+      return sum + (state?.power_consumption || 0);
+    }, 0);
+});
+
+// ---------- Mining performance aggregates (per OU) ----------
+interface UnitPerformance {
+  unitId: string;
+  unitName: string;
+  snapshot: MiningPerformanceSnapshot;
+}
+
+const unitPerformances = computed<UnitPerformance[]>(() => {
+  const out: UnitPerformance[] = [];
+  for (const [unitId, ctx] of latestDecisionalContexts.value.entries()) {
+    if (!ctx.mining_performance) continue;
+    const unit = optimizationUnitStore.optimizationUnits.find((u) => u.id === unitId);
+    out.push({
+      unitId,
+      unitName: unit?.name || unitId,
+      snapshot: ctx.mining_performance,
+    });
+  }
+  return out;
+});
+
+// Aggregated pool-side hashrate (sum across units, normalized to TH/s)
+const totalPoolHashRate = computed(() => {
+  let total = 0;
+  for (const p of unitPerformances.value) {
+    const hr = p.snapshot.current_hashrate;
+    if (hr?.value) total += normalizeHashRate(hr.value, hr.unit || "TH/s");
+  }
+  return total;
+});
+
+const totalPoolHashRate24h = computed(() => {
+  let total = 0;
+  for (const p of unitPerformances.value) {
+    const hr = p.snapshot.pool_stats?.average_hashrate_24h;
+    if (hr?.value) total += normalizeHashRate(hr.value, hr.unit || "TH/s");
+  }
+  return total;
+});
+
+const totalUnpaidBalance = computed(() => {
+  let total = 0;
+  for (const p of unitPerformances.value) {
+    const sats = p.snapshot.pool_stats?.unpaid_balance;
+    if (sats != null) total += sats;
+  }
+  return total;
+});
+
+const totalEstimatedPayout = computed(() => {
+  let total = 0;
+  for (const p of unitPerformances.value) {
+    const sats = p.snapshot.pool_stats?.estimated_next_payout;
+    if (sats != null) total += sats;
+  }
+  return total;
+});
+
+const totalWorkers = computed(() => {
+  let total = 0;
+  for (const p of unitPerformances.value) {
+    total += p.snapshot.pool_stats?.workers?.length ?? 0;
+  }
+  return total;
+});
+
+// Soonest next payout across all units
+const nextPayoutAt = computed<string | null>(() => {
+  let soonest: number | null = null;
+  for (const p of unitPerformances.value) {
+    const ts = p.snapshot.payout_schedule?.next_payout_at;
+    if (!ts) continue;
+    const t = new Date(ts).getTime();
+    if (soonest === null || t < soonest) soonest = t;
+  }
+  return soonest != null ? new Date(soonest).toISOString() : null;
+});
+
+const nextPayoutLabel = computed(() => {
+  void now.value;
+  if (!nextPayoutAt.value) return "-";
+  const diffMs = new Date(nextPayoutAt.value).getTime() - now.value;
+  if (diffMs <= 0) return "due";
+  const minutes = Math.floor(diffMs / 60000);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `in ~${days}d`;
+  if (hours > 0) return `in ~${hours}h`;
+  return `in ${minutes}m`;
+});
+
+// ---------- Formatters ----------
+function formatHashRateTH(thPerS: number): string {
+  if (thPerS === 0) return "-";
+  if (thPerS >= 1000) return `${(thPerS / 1000).toFixed(2)} PH/s`;
+  if (thPerS >= 1) return `${thPerS.toFixed(1)} TH/s`;
+  if (thPerS >= 0.001) return `${(thPerS * 1000).toFixed(0)} GH/s`;
+  return `${(thPerS * 1_000_000).toFixed(0)} MH/s`;
+}
+
+function formatSats(sats: number | null | undefined): string {
+  if (sats == null) return "-";
+  if (Math.abs(sats) >= 100_000_000) {
+    return `${(sats / 100_000_000).toFixed(4)} BTC`;
+  }
+  return `${sats.toLocaleString()} sat`;
+}
+
+const formattedDeviceHashRate = computed(() => formatHashRateTH(totalDeviceHashRate.value));
+const formattedPoolHashRate = computed(() => formatHashRateTH(totalPoolHashRate.value));
+const formattedPoolHashRate24h = computed(() => formatHashRateTH(totalPoolHashRate24h.value));
+</script>
+
+<template>
+  <div class="dashboard-root space-y-5">
+    <!-- Header -->
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold text-base-content">Mining</h1>
+        <p class="text-sm text-base-content/50 mt-0.5">
+          Pool performance, payouts &amp; miner devices
+        </p>
+      </div>
+      <div class="flex items-center gap-2 text-xs text-base-content/40">
+        <PhArrowsClockwise
+          :size="14"
+          :class="{ 'animate-spin': isPolling }"
+        />
+        <span>Updated {{ lastUpdateLabel }}</span>
+      </div>
+    </div>
+
+    <!-- KPI Strip -->
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-3">
+      <KpiCard
+        label="Pool Hash Rate"
+        :value="formattedPoolHashRate"
+        :sub-value="totalPoolHashRate24h > 0 ? `24h ${formattedPoolHashRate24h}` : ''"
+        :icon="PhTrendUp"
+        icon-color="text-primary"
+        icon-bg-color="bg-primary/15"
+        :value-color="totalPoolHashRate > 0 ? 'text-primary' : 'text-base-content/30'"
+      />
+      <KpiCard
+        label="Device Hash Rate"
+        :value="formattedDeviceHashRate"
+        :icon="PhCpu"
+        icon-color="text-emerald-400"
+        icon-bg-color="bg-emerald-400/15"
+        :value-color="totalDeviceHashRate > 0 ? 'text-emerald-400' : 'text-base-content/30'"
+      />
+      <KpiCard
+        label="Power Draw"
+        :value="totalDevicePower > 0 ? formatPower(totalDevicePower) : '-'"
+        :icon="PhLightning"
+        icon-color="text-warning"
+        icon-bg-color="bg-warning/15"
+        :value-color="totalDevicePower > 0 ? 'text-warning' : 'text-base-content/30'"
+      />
+      <KpiCard
+        label="Miners"
+        :value="`${runningMiners} / ${activeMiners}`"
+        :sub-value="`of ${totalMiners} total`"
+        :icon="PhPower"
+        icon-color="text-primary"
+        icon-bg-color="bg-primary/15"
+        value-color="text-primary"
+      />
+      <KpiCard
+        label="Workers"
+        :value="totalWorkers > 0 ? `${totalWorkers}` : '-'"
+        sub-value="reporting"
+        :icon="PhUsersFour"
+        icon-color="text-sky-400"
+        icon-bg-color="bg-sky-400/15"
+        :value-color="totalWorkers > 0 ? 'text-sky-400' : 'text-base-content/30'"
+      />
+      <KpiCard
+        label="Unpaid Balance"
+        :value="formatSats(totalUnpaidBalance > 0 ? totalUnpaidBalance : null)"
+        :sub-value="totalEstimatedPayout > 0 ? `est. ${formatSats(totalEstimatedPayout)}` : ''"
+        :icon="PhCurrencyBtc"
+        icon-color="text-yellow-400"
+        icon-bg-color="bg-yellow-400/15"
+        :value-color="totalUnpaidBalance > 0 ? 'text-yellow-400' : 'text-base-content/30'"
+      />
+      <KpiCard
+        label="Next Payout"
+        :value="nextPayoutLabel"
+        :icon="PhClockCountdown"
+        icon-color="text-teal-400"
+        icon-bg-color="bg-teal-400/15"
+        :value-color="nextPayoutAt ? 'text-teal-400' : 'text-base-content/30'"
+      />
+    </div>
+
+    <!-- Empty state when no performance tracker data -->
+    <div
+      v-if="unitPerformances.length === 0"
+      class="rounded-xl border border-base-300/20 bg-base-100/30 backdrop-blur-sm p-8 text-center"
+    >
+      <PhTrendUp :size="36" class="mx-auto text-base-content/15 mb-2" />
+      <span class="block text-sm text-base-content/40">
+        No mining performance data available
+      </span>
+      <span class="block text-xs text-base-content/30 mt-1">
+        Assign a performance tracker to an optimization unit to see pool stats here.
+      </span>
+    </div>
+
+    <!-- Per-unit Pool Stats and Payout -->
+    <div
+      v-for="perf in unitPerformances"
+      :key="perf.unitId"
+      class="space-y-3"
+    >
+      <div class="flex items-center gap-2">
+        <PhTrendUp :size="16" class="text-base-content/40" />
+        <h2 class="text-sm font-semibold text-base-content/60 uppercase tracking-wider">
+          {{ perf.unitName }}
+        </h2>
+        <span class="text-[10px] text-base-content/30 ml-auto">
+          {{ formatTimeAgo(perf.snapshot.timestamp) }}
+        </span>
+      </div>
+      <div class="grid grid-cols-1 lg:grid-cols-3 gap-3">
+        <PoolStatsCard
+          class="lg:col-span-2"
+          :snapshot="perf.snapshot"
+        />
+        <PayoutCard :snapshot="perf.snapshot" />
+      </div>
+    </div>
+
+    <!-- Miner Fleet -->
+    <div>
+      <div class="flex items-center gap-2 mb-3">
+        <PhCpu :size="16" class="text-base-content/40" />
+        <h2 class="text-sm font-semibold text-base-content/60 uppercase tracking-wider">
+          Miner Fleet
+        </h2>
+        <span class="text-xs text-base-content/30 ml-auto">
+          {{ runningMiners }} running
+        </span>
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <MinerTile
+          v-for="miner in minerStore.miners"
+          :key="miner.id"
+          :miner="miner"
+          :state="miner.id ? minerStore.minerStates.get(miner.id) : undefined"
+        />
+        <div
+          v-if="minerStore.miners.length === 0"
+          class="col-span-full flex flex-col items-center py-12 text-center"
+        >
+          <PhCpu :size="36" class="text-base-content/15 mb-2" />
+          <span class="text-sm text-base-content/30">No miners configured</span>
+          <RouterLink to="/settings/miners" class="text-xs text-primary/60 hover:text-primary mt-1">
+            Add miners in Settings
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+
+    <!-- Per-miner detailed runtime state (from miner_state in decisional context) -->
+    <div v-if="minerStore.miners.length > 0">
+      <div class="flex items-center gap-2 mb-3">
+        <PhCpu :size="16" class="text-base-content/40" />
+        <h2 class="text-sm font-semibold text-base-content/60 uppercase tracking-wider">
+          Miner Runtime State
+        </h2>
+      </div>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        <MinerStateCard
+          v-for="miner in minerStore.miners"
+          :key="miner.id"
+          :miner="miner"
+          :state="miner.id ? minerStore.minerStates.get(miner.id) : undefined"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped></style>

--- a/src/views/dashboard/MiningDashboardView.vue
+++ b/src/views/dashboard/MiningDashboardView.vue
@@ -5,7 +5,6 @@ import { useOptimizationUnitStore } from "../../core/stores/optimizationUnitStor
 import { useDashboardPolling } from "../../core/composables/useDashboardPolling";
 import { normalizeHashRate, formatPower, formatTimeAgo } from "../../core/utils/index";
 import KpiCard from "../../components/dashboard/KpiCard.vue";
-import MinerTile from "../../components/dashboard/MinerTile.vue";
 import PoolStatsCard from "../../components/mining/PoolStatsCard.vue";
 import PayoutCard from "../../components/mining/PayoutCard.vue";
 import MinerStateCard from "../../components/mining/MinerStateCard.vue";
@@ -305,46 +304,25 @@ const formattedPoolHashRate24h = computed(() => formatHashRateTH(totalPoolHashRa
       </div>
     </div>
 
-    <!-- Miner Fleet -->
+    <!-- Per-miner runtime state (from miner_state in decisional context) -->
     <div>
-      <div class="flex items-center gap-2 mb-3">
-        <PhCpu :size="16" class="text-base-content/40" />
-        <h2 class="text-sm font-semibold text-base-content/60 uppercase tracking-wider">
-          Miner Fleet
-        </h2>
-        <span class="text-xs text-base-content/30 ml-auto">
-          {{ runningMiners }} running
-        </span>
-      </div>
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
-        <MinerTile
-          v-for="miner in minerStore.miners"
-          :key="miner.id"
-          :miner="miner"
-          :state="miner.id ? minerStore.minerStates.get(miner.id) : undefined"
-        />
-        <div
-          v-if="minerStore.miners.length === 0"
-          class="col-span-full flex flex-col items-center py-12 text-center"
-        >
-          <PhCpu :size="36" class="text-base-content/15 mb-2" />
-          <span class="text-sm text-base-content/30">No miners configured</span>
-          <RouterLink to="/settings/miners" class="text-xs text-primary/60 hover:text-primary mt-1">
-            Add miners in Settings
-          </RouterLink>
-        </div>
-      </div>
-    </div>
-
-    <!-- Per-miner detailed runtime state (from miner_state in decisional context) -->
-    <div v-if="minerStore.miners.length > 0">
       <div class="flex items-center gap-2 mb-3">
         <PhCpu :size="16" class="text-base-content/40" />
         <h2 class="text-sm font-semibold text-base-content/60 uppercase tracking-wider">
           Miner Runtime State
         </h2>
+        <span class="text-xs text-base-content/30 ml-auto">
+          {{ runningMiners }} running
+        </span>
       </div>
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-3">
+      <div v-if="minerStore.miners.length === 0" class="flex flex-col items-center py-12 text-center">
+        <PhCpu :size="36" class="text-base-content/15 mb-2" />
+        <span class="text-sm text-base-content/30">No miners configured</span>
+        <RouterLink to="/settings/miners" class="text-xs text-primary/60 hover:text-primary mt-1">
+          Add miners in Settings
+        </RouterLink>
+      </div>
+      <div v-else class="grid grid-cols-1 lg:grid-cols-2 gap-3">
         <MinerStateCard
           v-for="miner in minerStore.miners"
           :key="miner.id"

--- a/src/views/settings/OptimizationUnitsSettingsView.vue
+++ b/src/views/settings/OptimizationUnitsSettingsView.vue
@@ -6,6 +6,7 @@ import { useMinerStore } from "../../core/stores/minerStore";
 import { useEnergySourceStore } from "../../core/stores/energySourceStore";
 import { useForecastProviderStore } from "../../core/stores/forecastProviderStore";
 import { useNotifierStore } from "../../core/stores/notifierStore";
+import { usePerformanceTrackerStore } from "../../core/stores/performanceTrackerStore";
 import OptimizationUnitCard from "../../components/optimizationUnits/OptimizationUnitCard.vue";
 import OptimizationUnitFormModal from "../../components/optimizationUnits/OptimizationUnitFormModal.vue";
 import type { OptimizationUnit } from "../../core/models/optimizationUnit";
@@ -22,6 +23,7 @@ const minerStore = useMinerStore();
 const energySourceStore = useEnergySourceStore();
 const forecastProviderStore = useForecastProviderStore();
 const notifierStore = useNotifierStore();
+const performanceTrackerStore = usePerformanceTrackerStore();
 
 // Modal state
 const showModal = ref(false);
@@ -66,6 +68,7 @@ onMounted(() => {
   energySourceStore.loadEnergySources();
   forecastProviderStore.loadForecastProviders();
   notifierStore.loadNotifiers();
+  performanceTrackerStore.loadPerformanceTrackers();
 });
 
 function openAddModal() {

--- a/src/views/settings/PerformanceTrackersSettingsView.vue
+++ b/src/views/settings/PerformanceTrackersSettingsView.vue
@@ -1,0 +1,361 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { usePerformanceTrackerStore } from "../../core/stores/performanceTrackerStore";
+import { useExternalServiceStore } from "../../core/stores/externalServiceStore";
+import { useOptimizationUnitStore } from "../../core/stores/optimizationUnitStore";
+import { useAppStore } from "../../core/stores/appStore";
+import PerformanceTrackerCard from "../../components/performanceTrackers/PerformanceTrackerCard.vue";
+import PerformanceTrackerFormModal from "../../components/performanceTrackers/PerformanceTrackerFormModal.vue";
+import type { PerformanceTracker } from "../../core/models/performanceTracker";
+import {
+  PhPlus,
+  PhChartLineUp,
+  PhGear,
+  PhBracketsCurly,
+  PhWaves,
+  PhLightning,
+} from "@phosphor-icons/vue";
+
+const performanceTrackerStore = usePerformanceTrackerStore();
+const externalServiceStore = useExternalServiceStore();
+const optimizationUnitStore = useOptimizationUnitStore();
+const appStore = useAppStore();
+
+const showModal = ref(false);
+const editingTracker = ref<PerformanceTracker | undefined>(undefined);
+const isEditMode = ref(false);
+
+const selectedAdapterFilter = ref<string>("all");
+
+function getAdapterIcon(type: string) {
+  const icons: Record<string, typeof PhGear> = {
+    dummy: PhBracketsCurly,
+    ocean: PhWaves,
+    braiins_pool: PhLightning,
+  };
+  return icons[type.toLowerCase()] || PhChartLineUp;
+}
+
+const adapterFilters = computed(() => {
+  const types = performanceTrackerStore.adapterTypes;
+  return [
+    { value: "all", label: "All", icon: PhChartLineUp },
+    ...types.map((type) => ({
+      value: type,
+      label: formatAdapterType(type),
+      icon: getAdapterIcon(type),
+    })),
+  ];
+});
+
+const filteredTrackers = computed(() => {
+  if (selectedAdapterFilter.value === "all") {
+    return performanceTrackerStore.performanceTrackers;
+  }
+  return performanceTrackerStore.performanceTrackers.filter(
+    (t) => t.adapter_type === selectedAdapterFilter.value
+  );
+});
+
+const stats = computed(() => {
+  const trackers = performanceTrackerStore.performanceTrackers;
+  const totalTrackers = trackers.length;
+
+  const linkedTrackers = trackers.filter((t) => t.external_service_id).length;
+
+  const trackerIdsInUnits = new Set(
+    optimizationUnitStore.optimizationUnits
+      .map((u) => u.performance_tracker_id)
+      .filter(Boolean) as string[]
+  );
+  const trackersInUse = trackers.filter((t) =>
+    t.id ? trackerIdsInUnits.has(t.id) : false
+  ).length;
+
+  const adapterCounts = trackers.reduce((acc, t) => {
+    acc[t.adapter_type] = (acc[t.adapter_type] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  return {
+    totalTrackers,
+    linkedTrackers,
+    trackersInUse,
+    adapterCounts,
+  };
+});
+
+onMounted(() => {
+  performanceTrackerStore.loadPerformanceTrackers();
+  performanceTrackerStore.loadAdapterTypes();
+  externalServiceStore.loadExternalServices();
+  optimizationUnitStore.loadOptimizationUnits();
+});
+
+function formatAdapterType(type: string): string {
+  return type
+    .split("_")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+function openAddModal() {
+  editingTracker.value = undefined;
+  isEditMode.value = false;
+  showModal.value = true;
+}
+
+function handleEdit(tracker: PerformanceTracker) {
+  editingTracker.value = { ...tracker };
+  isEditMode.value = true;
+  showModal.value = true;
+}
+
+function handleCloseModal() {
+  showModal.value = false;
+  editingTracker.value = undefined;
+}
+
+function handleSave(tracker: PerformanceTracker) {
+  if (isEditMode.value && tracker.id) {
+    performanceTrackerStore
+      .updatePerformanceTracker(tracker.id.toString(), tracker)
+      .then(() => {
+        performanceTrackerStore.loadPerformanceTrackers();
+        handleCloseModal();
+      })
+      .showToasts(
+        "Performance tracker updated successfully",
+        "Failed to update performance tracker"
+      );
+  } else {
+    performanceTrackerStore
+      .addPerformanceTracker(tracker)
+      .then(() => {
+        performanceTrackerStore.loadPerformanceTrackers();
+        handleCloseModal();
+      })
+      .showToasts(
+        "Performance tracker created successfully",
+        "Failed to create performance tracker"
+      );
+  }
+}
+
+function handleDelete(tracker: PerformanceTracker) {
+  performanceTrackerStore
+    .deletePerformanceTracker(tracker.id!.toString())
+    .then(() => {
+      performanceTrackerStore.loadPerformanceTrackers();
+      optimizationUnitStore.loadOptimizationUnits();
+    })
+    .showToasts(
+      "Performance tracker deleted successfully",
+      "Failed to delete performance tracker"
+    );
+}
+
+function handleTest(tracker: PerformanceTracker) {
+  if (!tracker.id) return;
+  performanceTrackerStore
+    .testPerformanceTracker(tracker.id.toString())
+    .then((result) => {
+      appStore.showSuccessToast(
+        result?.message || "Performance tracker is reachable"
+      );
+    })
+    .catch((err) => {
+      const detail = err?.response?.data?.detail || err?.message || "Failed to test performance tracker";
+      appStore.showErrorToast(detail);
+    });
+}
+
+function getFilterCount(adapterType: string): number {
+  if (adapterType === "all") return stats.value.totalTrackers;
+  return stats.value.adapterCounts[adapterType] || 0;
+}
+</script>
+
+<template>
+  <div class="card">
+    <div class="card-header">
+      <div class="flex flex-col lg:flex-row lg:items-center justify-between gap-4">
+        <div>
+          <h1 class="text-2xl font-bold text-base-content">Performance Trackers</h1>
+          <p class="text-sm text-base-content/60 mt-1">
+            Configure mining pool performance trackers for hashrate and rewards monitoring
+          </p>
+        </div>
+
+        <button class="btn btn-primary gap-2" @click="openAddModal">
+          <PhPlus :size="20" weight="bold" />
+          Add Tracker
+        </button>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="space-y-6">
+        <!-- Stats Cards -->
+        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-3 sm:gap-4">
+          <div class="stat-card bg-neutral-800/80 border border-base-300/40 rounded-xl p-3 sm:p-4 min-w-0">
+            <div class="stat-value text-primary">{{ stats.totalTrackers }}</div>
+            <div class="stat-label">Total Trackers</div>
+          </div>
+          <div class="stat-card bg-neutral-800/80 border border-base-300/40 rounded-xl p-3 sm:p-4 min-w-0">
+            <div class="stat-value text-teal-400">{{ stats.trackersInUse }}</div>
+            <div class="stat-label">In Use</div>
+          </div>
+          <div class="stat-card bg-neutral-800/80 border border-base-300/40 rounded-xl p-3 sm:p-4 min-w-0">
+            <div class="stat-value text-info">{{ stats.linkedTrackers }}</div>
+            <div class="stat-label">With External Service</div>
+          </div>
+          <div class="stat-card bg-neutral-800/80 border border-base-300/40 rounded-xl p-3 sm:p-4 min-w-0 overflow-hidden">
+            <div class="flex flex-wrap gap-2 sm:gap-3 items-center min-h-[2rem] sm:min-h-[2.25rem]">
+              <div
+                v-for="(count, adapterType) in stats.adapterCounts"
+                :key="adapterType"
+                class="flex items-center gap-0.5 sm:gap-1"
+              >
+                <component
+                  :is="getAdapterIcon(String(adapterType))"
+                  :size="18"
+                  class="text-cyan-400 flex-shrink-0 sm:w-6 sm:h-6"
+                />
+                <span class="stat-type-count">{{ count }}</span>
+              </div>
+              <div
+                v-if="Object.keys(stats.adapterCounts).length === 0"
+                class="text-base-content/40"
+              >
+                -
+              </div>
+            </div>
+            <div class="stat-label">By Adapter</div>
+          </div>
+        </div>
+
+        <!-- Filter Tabs -->
+        <div class="flex gap-2 flex-wrap">
+          <button
+            v-for="filter in adapterFilters"
+            :key="filter.value"
+            class="btn btn-sm gap-2 transition-all"
+            :class="[
+              selectedAdapterFilter === filter.value
+                ? 'btn-primary'
+                : 'btn-ghost opacity-70 hover:opacity-100',
+            ]"
+            @click="selectedAdapterFilter = filter.value"
+          >
+            <component :is="filter.icon" :size="16" />
+            {{ filter.label }}
+            <span
+              v-if="getFilterCount(filter.value) > 0"
+              class="badge badge-sm"
+              :class="
+                selectedAdapterFilter === filter.value
+                  ? 'bg-white/20 text-neutral-900'
+                  : 'badge-neutral'
+              "
+            >
+              {{ getFilterCount(filter.value) }}
+            </span>
+          </button>
+        </div>
+
+        <!-- Cards Grid -->
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          <PerformanceTrackerCard
+            v-for="tracker in filteredTrackers"
+            :key="tracker.id"
+            :tracker="tracker"
+            :all-optimization-units="optimizationUnitStore.optimizationUnits"
+            @edit="handleEdit"
+            @delete="handleDelete"
+            @test="handleTest"
+          />
+
+          <!-- Empty state -->
+          <div
+            v-if="filteredTrackers.length === 0"
+            class="col-span-full flex flex-col items-center justify-center py-16 text-center"
+          >
+            <div
+              class="w-20 h-20 rounded-full bg-base-200 flex items-center justify-center mb-4"
+            >
+              <PhChartLineUp :size="40" class="text-base-content/30" />
+            </div>
+            <h3 class="text-lg font-semibold text-base-content/80">
+              {{
+                selectedAdapterFilter === "all"
+                  ? "No performance trackers yet"
+                  : "No trackers of this type"
+              }}
+            </h3>
+            <p class="text-sm text-base-content/50 mt-1 max-w-sm">
+              {{
+                selectedAdapterFilter === "all"
+                  ? "Add your first performance tracker to monitor hashrate and rewards from your mining pool."
+                  : "Try selecting a different filter or add a new tracker."
+              }}
+            </p>
+            <button
+              v-if="selectedAdapterFilter === 'all'"
+              class="btn btn-primary btn-sm mt-4 gap-2"
+              @click="openAddModal"
+            >
+              <PhPlus :size="16" />
+              Add Tracker
+            </button>
+          </div>
+        </div>
+
+        <!-- Form Modal -->
+        <PerformanceTrackerFormModal
+          :open="showModal"
+          :performance-tracker="editingTracker"
+          :is-edit="isEditMode"
+          @close="handleCloseModal"
+          @save="handleSave"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.stat-card {
+  transition: all 0.2s ease;
+}
+
+.stat-card:hover {
+  border-color: oklch(50% 0 0 / 0.5);
+}
+
+.stat-value {
+  font-weight: 700;
+  font-size: clamp(1.25rem, 4vw, 1.875rem);
+  line-height: 1.2;
+}
+
+.stat-label {
+  font-size: clamp(0.7rem, 2vw, 0.875rem);
+  color: oklch(80% 0 0 / 0.6);
+  margin-top: 0.125rem;
+}
+
+.stat-type-count {
+  font-weight: 600;
+  font-size: clamp(0.875rem, 2.5vw, 1.25rem);
+}
+
+@media (max-width: 640px) {
+  .stat-value {
+    font-size: 1.25rem;
+  }
+
+  .stat-type-count {
+    font-size: 0.875rem;
+  }
+}
+</style>


### PR DESCRIPTION
This PR brings the new **Mining Performance** data from the core into the web app, together with a dedicated dashboard to inspect it at a glance.

## What's new

### 1. Performance Trackers management
A new section under **Mining → Performance Trackers** in the sidebar lets users create, configure and manage performance trackers. Three adapters are supported out of the box:
- **Dummy** – useful for local testing
- **Ocean** – via Ocean public API
- **Braiins Pool** – via a Braiins access token

Each tracker is just a named adapter with its own configuration; once created it can be linked to an Optimization Unit so that mining performance becomes part of the decision-making context.

<img width="1904" height="826" alt="image" src="https://github.com/user-attachments/assets/7bd85015-b547-49c5-a4f2-9cafe904604d" />

<img width="714" height="875" alt="image" src="https://github.com/user-attachments/assets/1df440bc-489c-4dee-acae-1a428c976648" />


### 2. Assign Mining Performance Tracker

Next is possible to assign the performance tracker to an optimization unit.

<img width="702" height="955" alt="image" src="https://github.com/user-attachments/assets/7d2bbdc7-da8b-4605-bcd4-5c78f3956a5e" />


### 3. New "Mining" dashboard
The sidebar **Dashboard** entry is now a submenu with two pages:
- **Overview** – the existing energy/mining landing page (unchanged)
- **Mining** – a new page dedicated to pool and device performance

The new **Mining** dashboard shows, for each Optimization Unit that has a performance tracker configured:

- **Pool stats**
  - Current hashrate reported by the pool
  - 24h and 7d average hashrate
  - Live list of workers, each with its hashrate, valid / stale / rejected shares and time of the last share
- **Payout info**
  - Unpaid balance (in sat or BTC, auto-formatted)
  - Estimated next payout
  - Payout frequency (daily / weekly / monthly / threshold) and threshold
  - Next scheduled payout time with countdown

At the top of the page a compact KPI strip summarises the fleet: pool hashrate, device hashrate, power draw, running miners, reporting workers, total unpaid balance and time to next payout.

Below the pool data, a **Miner Runtime State** section lists each miner with its live values: hashrate, power, uptime, max chip/board temperature, fan speed, blocks found and per-hashboard detail.

<img width="1692" height="1014" alt="edgemining-mining-dashboard" src="https://github.com/user-attachments/assets/c8bb4557-e46f-43b4-9fc4-6cc7daab10ee" />


### 4. Supporting changes
- Frontend `DecisionalContext` model aligned with the core: the legacy `tracker_current_hashrate` field is replaced by the richer `mining_performance` snapshot (hashrate + pool stats + payout schedule).
- Minor refactor of the miner runtime display on the Mining dashboard to avoid duplicated cards.

## How to try it

1. Create or configure a Performance Tracker from **Mining → Performance Trackers**.
2. Assign it to an Optimization Unit (in **Optimization → Units**).
3. Open **Dashboard → Mining** to see the pool stats, payouts and miner runtime state update live.

## Screens affected
- Sidebar: **Dashboard** is now expandable (Overview / Mining).
- New page: `/dashboard/mining`.
- Existing Overview dashboard: unchanged.
